### PR TITLE
Running the dry boundary layer example case

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ In order to compile MicroHH you need:
 * CMake
 * MPI2/3 implementation (optional for MPI support)
 * CUDA (optional for GPU support)
-* Doxygen (optional for creating automatic documentation)
+* Doxygen + Graphviz (optional for creating automatic documentation)
 * Python + numpy (optional for running example cases)
 * Ipython + python-netcdf4 + matplotlib (optional for plotting results example cases)
 

--- a/cases/drycblles/drycbllesstats.py
+++ b/cases/drycblles/drycbllesstats.py
@@ -8,20 +8,20 @@ start = 0
 end   = 19
 step  = 2
 
-stats = netCDF4.Dataset("drycblles.0000000.nc","r")
+stats = netCDF4.Dataset("drycblles.default.0000000.nc","r")
 t  = stats.variables["t"][start:end]
 z  = stats.variables["z"][:]
 zh = stats.variables["zh"][:]
-st  = stats.variables["s"][start:end,:]
+st  = stats.variables["th"][start:end,:]
 evisct = stats.variables["evisc"][start:end,:]
 u2t = stats.variables["u2"][start:end,:]
 v2t = stats.variables["v2"][start:end,:]
 w2t = stats.variables["w2"][start:end,:]
-s2t = stats.variables["s2"][start:end,:]
-sturbt = stats.variables["sw"][start:end,:]
-sdifft = stats.variables["sdiff"][start:end,:]
-sfluxt = stats.variables["sflux"][start:end,:]
-sgradt = stats.variables["sgrad"][start:end,:]
+s2t = stats.variables["th2"][start:end,:]
+sturbt = stats.variables["thw"][start:end,:]
+sdifft = stats.variables["thdiff"][start:end,:]
+sfluxt = stats.variables["thflux"][start:end,:]
+sgradt = stats.variables["thgrad"][start:end,:]
 
 s = numpy.mean(st,0)
 evisc = numpy.mean(evisct,0)

--- a/config/macbook.cmake
+++ b/config/macbook.cmake
@@ -25,7 +25,7 @@ set(LIBS ${FFTW_LIB} ${NETCDF_LIB_CPP} ${NETCDF_LIB_C} ${HDF5_LIB_2} ${HDF5_LIB_
 
 if(USECUDA)
   set(CUDA_PROPAGATE_HOST_FLAGS OFF)
-  set(LIBS ${LIBS} -rdynamic /usr/local/cuda/lib64/libcufft.so)
+  set(LIBS ${LIBS} -rdynamic /usr/local/cuda/lib/libcufft.dylib)
   set(USER_CUDA_NVCC_FLAGS "-arch=sm_20")
 endif()
 

--- a/config/macbook_brew.cmake
+++ b/config/macbook_brew.cmake
@@ -25,7 +25,7 @@ set(LIBS ${FFTW_LIB} ${NETCDF_LIB_CPP} ${NETCDF_LIB_C} ${HDF5_LIB_2} ${HDF5_LIB_
 
 if(USECUDA)
   set(CUDA_PROPAGATE_HOST_FLAGS OFF)
-  set(LIBS ${LIBS} -rdynamic /usr/local/cuda/lib64/libcufft.so)
+  set(LIBS ${LIBS} -rdynamic /usr/local/cuda/lib/libcufft.dylib)
   set(USER_CUDA_NVCC_FLAGS "-arch=sm_20")
 endif()
 

--- a/config/macbook_brew_gcc.cmake
+++ b/config/macbook_brew_gcc.cmake
@@ -25,7 +25,7 @@ set(LIBS ${FFTW_LIB} ${NETCDF_LIB_CPP} ${NETCDF_LIB_C} ${HDF5_LIB_2} ${HDF5_LIB_
 
 if(USECUDA)
   set(CUDA_PROPAGATE_HOST_FLAGS OFF)
-  set(LIBS ${LIBS} -rdynamic /usr/local/cuda/lib64/libcufft.so)
+  set(LIBS ${LIBS} -rdynamic /usr/local/cuda/lib/libcufft.dylib)
   set(USER_CUDA_NVCC_FLAGS "-arch=sm_20")
 endif()
 

--- a/config/macbook_clang.cmake
+++ b/config/macbook_clang.cmake
@@ -26,7 +26,7 @@ set(LIBS ${FFTW_LIB} ${NETCDF_LIB_CPP} ${NETCDF_LIB_C} ${HDF5_LIB_2} ${HDF5_LIB_
 
 if(USECUDA)
   set(CUDA_PROPAGATE_HOST_FLAGS OFF)
-  set(LIBS ${LIBS} -rdynamic /usr/local/cuda/lib64/libcufft.so)
+  set(LIBS ${LIBS} -rdynamic /usr/local/cuda/lib/libcufft.dylib)
   set(USER_CUDA_NVCC_FLAGS "-arch=sm_20")
 endif()
 


### PR DESCRIPTION
Hi Chiel,

we met two/three times at MPI-HH. I visited a couple of times from BTU Cottbus and worked on the UCLA-LES.

I re-familiarize myself with CUDA and am looking into MicroHH as a real world example. I made two changes to it to make the drycblles example work as in the README. First, I changes the paths to libcufft so MicroHH compiles on a Mac with CUDA enabled. Second, I used 'th' instead of 's' in the plotting script, since 's' is not present in the netCDF file and is plotted as theta anyway.

--
Eckhard