### PR TITLE
Fix flux statistics

### DIFF
--- a/include/advec.h
+++ b/include/advec.h
@@ -56,7 +56,7 @@ class Advec
         virtual unsigned long get_time_limit(unsigned long, double) = 0; ///< Get the maximum time step imposed by advection scheme
         virtual double get_cfl(double) = 0; ///< Retrieve the CFL number.
 
-        virtual void get_advec_flux(Field3d<TF>&, const Field3d<TF>&) = 0;
+        virtual void get_advec_flux(Field3d<TF>&, const Field3d<TF>&, const Field3d<TF>&) = 0;
         virtual Advection_type get_switch() const = 0;
 
     protected:

--- a/include/advec_2.h
+++ b/include/advec_2.h
@@ -46,7 +46,7 @@ class Advec_2 : public Advec<TF>
         unsigned long get_time_limit(long unsigned int, double); ///< Get the limit on the time step imposed by the advection scheme.
         double get_cfl(double); ///< Get the CFL number.
 
-        void get_advec_flux(Field3d<TF>&, const Field3d<TF>&);
+        void get_advec_flux(Field3d<TF>&, const Field3d<TF>&, const Field3d<TF>&);
         Advection_type get_switch() const { return Advection_type::Advec_2; }
 
     private:

--- a/include/advec_2i4.h
+++ b/include/advec_2i4.h
@@ -46,7 +46,7 @@ class Advec_2i4 : public Advec<TF>
         unsigned long get_time_limit(long unsigned int, double); ///< Get the limit on the time step imposed by the advection scheme.
         double get_cfl(double); ///< Get the CFL number.
 
-        void get_advec_flux(Field3d<TF>&, const Field3d<TF>&);
+        void get_advec_flux(Field3d<TF>&, const Field3d<TF>&, const Field3d<TF>&);
         Advection_type get_switch() const { return Advection_type::Advec_2i4; }
 
     private:

--- a/include/advec_2i5.h
+++ b/include/advec_2i5.h
@@ -46,7 +46,7 @@ class Advec_2i5 : public Advec<TF>
         unsigned long get_time_limit(long unsigned int, double); ///< Get the limit on the time step imposed by the advection scheme.
         double get_cfl(double); ///< Get the CFL number.
 
-        void get_advec_flux(Field3d<TF>&, const Field3d<TF>&);
+        void get_advec_flux(Field3d<TF>&, const Field3d<TF>&, const Field3d<TF>&);
         Advection_type get_switch() const { return Advection_type::Advec_2i5; }
 
     private:

--- a/include/advec_2i53.h
+++ b/include/advec_2i53.h
@@ -46,7 +46,7 @@ class Advec_2i53 : public Advec<TF>
         unsigned long get_time_limit(long unsigned int, double); ///< Get the limit on the time step imposed by the advection scheme.
         double get_cfl(double); ///< Get the CFL number.
 
-        void get_advec_flux(Field3d<TF>&, const Field3d<TF>&);
+        void get_advec_flux(Field3d<TF>&, const Field3d<TF>&, const Field3d<TF>&);
         Advection_type get_switch() const { return Advection_type::Advec_2i53; }
 
     private:

--- a/include/advec_2i62.h
+++ b/include/advec_2i62.h
@@ -46,7 +46,7 @@ class Advec_2i62 : public Advec<TF>
         unsigned long get_time_limit(long unsigned int, double); ///< Get the limit on the time step imposed by the advection scheme.
         double get_cfl(double); ///< Get the CFL number.
 
-        void get_advec_flux(Field3d<TF>&, const Field3d<TF>&);
+        void get_advec_flux(Field3d<TF>&, const Field3d<TF>&, const Field3d<TF>&);
         Advection_type get_switch() const { return Advection_type::Advec_2i62; }
 
     private:

--- a/include/advec_4.h
+++ b/include/advec_4.h
@@ -46,7 +46,7 @@ class Advec_4 : public Advec<TF>
         unsigned long get_time_limit(long unsigned int, double); ///< Get the limit on the time step imposed by the advection scheme.
         double get_cfl(double); ///< Get the CFL number.
 
-        void get_advec_flux(Field3d<TF>&, const Field3d<TF>&);
+        void get_advec_flux(Field3d<TF>&, const Field3d<TF>&, const Field3d<TF>&);
         Advection_type get_switch() const { return Advection_type::Advec_4; }
 
     private:

--- a/include/advec_4m.h
+++ b/include/advec_4m.h
@@ -46,7 +46,7 @@ class Advec_4m : public Advec<TF>
         unsigned long get_time_limit(long unsigned int, double); ///< Get the limit on the time step imposed by the advection scheme.
         double get_cfl(double); ///< Get the CFL number.
 
-        void get_advec_flux(Field3d<TF>&, const Field3d<TF>&);
+        void get_advec_flux(Field3d<TF>&, const Field3d<TF>&, const Field3d<TF>&);
         Advection_type get_switch() const { return Advection_type::Advec_4m; }
 
     private:

--- a/include/advec_disabled.h
+++ b/include/advec_disabled.h
@@ -42,7 +42,7 @@ class Advec_disabled : public Advec<TF>
         unsigned long get_time_limit(unsigned long, double); ///< Get the maximum time step imposed by advection scheme
         double get_cfl(double); ///< Retrieve the CFL number.
 
-        void get_advec_flux(Field3d<TF>&, const Field3d<TF>&);
+        void get_advec_flux(Field3d<TF>&, const Field3d<TF>&, const Field3d<TF>&);
         Advection_type get_switch() const { return Advection_type::Disabled; }
 
     private:

--- a/src/advec_2.cxx
+++ b/src/advec_2.cxx
@@ -336,7 +336,8 @@ void Advec_2<TF>::exec(Stats<TF>& stats)
 #endif
 
 template<typename TF>
-void Advec_2<TF>::get_advec_flux(Field3d<TF>& advec_flux, const Field3d<TF>& fld)
+void Advec_2<TF>::get_advec_flux(
+        Field3d<TF>& advec_flux, const Field3d<TF>& fld, const Field3d<TF>& w)
 {
     auto& gd = grid.get_grid_data();
 

--- a/src/advec_2.cxx
+++ b/src/advec_2.cxx
@@ -344,21 +344,21 @@ void Advec_2<TF>::get_advec_flux(
     if (fld.loc == gd.uloc)
     {
         advec_flux_u(
-                advec_flux.fld.data(), fld.fld.data(), fields.mp.at("w")->fld.data(),
+                advec_flux.fld.data(), fld.fld.data(), w.fld.data(),
                 gd.istart, gd.iend, gd.jstart, gd.jend, gd.kstart, gd.kend,
                 gd.icells, gd.ijcells);
     }
     else if (fld.loc == gd.vloc)
     {
         advec_flux_v(
-                advec_flux.fld.data(), fld.fld.data(), fields.mp.at("w")->fld.data(),
+                advec_flux.fld.data(), fld.fld.data(), w.fld.data(),
                 gd.istart, gd.iend, gd.jstart, gd.jend, gd.kstart, gd.kend,
                 gd.icells, gd.ijcells);
     }
     else if (fld.loc == gd.sloc)
     {
         advec_flux_s(
-                advec_flux.fld.data(), fld.fld.data(), fields.mp.at("w")->fld.data(),
+                advec_flux.fld.data(), fld.fld.data(), w.fld.data(),
                 gd.istart, gd.iend, gd.jstart, gd.jend, gd.kstart, gd.kend,
                 gd.icells, gd.ijcells);
     }

--- a/src/advec_2i4.cxx
+++ b/src/advec_2i4.cxx
@@ -721,7 +721,8 @@ void Advec_2i4<TF>::exec(Stats<TF>& stats)
 #endif
 
 template<typename TF>
-void Advec_2i4<TF>::get_advec_flux(Field3d<TF>& advec_flux, const Field3d<TF>& fld)
+void Advec_2i4<TF>::get_advec_flux(
+        Field3d<TF>& advec_flux, const Field3d<TF>& fld, const Field3d<TF>& w)
 {
     auto& gd = grid.get_grid_data();
 

--- a/src/advec_2i4.cxx
+++ b/src/advec_2i4.cxx
@@ -729,21 +729,21 @@ void Advec_2i4<TF>::get_advec_flux(
     if (fld.loc == gd.uloc)
     {
         advec_flux_u(
-                advec_flux.fld.data(), fld.fld.data(), fields.mp.at("w")->fld.data(),
+                advec_flux.fld.data(), fld.fld.data(), w.fld.data(),
                 gd.istart, gd.iend, gd.jstart, gd.jend, gd.kstart, gd.kend,
                 gd.icells, gd.ijcells);
     }
     else if (fld.loc == gd.vloc)
     {
         advec_flux_v(
-                advec_flux.fld.data(), fld.fld.data(), fields.mp.at("w")->fld.data(),
+                advec_flux.fld.data(), fld.fld.data(), w.fld.data(),
                 gd.istart, gd.iend, gd.jstart, gd.jend, gd.kstart, gd.kend,
                 gd.icells, gd.ijcells);
     }
     else if (fld.loc == gd.sloc)
     {
         advec_flux_s(
-                advec_flux.fld.data(), fld.fld.data(), fields.mp.at("w")->fld.data(),
+                advec_flux.fld.data(), fld.fld.data(), w.fld.data(),
                 gd.istart, gd.iend, gd.jstart, gd.jend, gd.kstart, gd.kend,
                 gd.icells, gd.ijcells);
     }

--- a/src/advec_2i5.cxx
+++ b/src/advec_2i5.cxx
@@ -1045,7 +1045,8 @@ void Advec_2i5<TF>::exec(Stats<TF>& stats)
 #endif
 
 template<typename TF>
-void Advec_2i5<TF>::get_advec_flux(Field3d<TF>& advec_flux, const Field3d<TF>& fld)
+void Advec_2i5<TF>::get_advec_flux(
+        Field3d<TF>& advec_flux, const Field3d<TF>& fld, const Field3d<TF>& w)
 {
     auto& gd = grid.get_grid_data();
 

--- a/src/advec_2i5.cxx
+++ b/src/advec_2i5.cxx
@@ -1053,14 +1053,14 @@ void Advec_2i5<TF>::get_advec_flux(
     if (fld.loc == gd.uloc)
     {
         advec_flux_u(
-                advec_flux.fld.data(), fld.fld.data(), fields.mp.at("w")->fld.data(),
+                advec_flux.fld.data(), fld.fld.data(), w.fld.data(),
                 gd.istart, gd.iend, gd.jstart, gd.jend, gd.kstart, gd.kend,
                 gd.icells, gd.ijcells);
     }
     else if (fld.loc == gd.vloc)
     {
         advec_flux_v(
-                advec_flux.fld.data(), fld.fld.data(), fields.mp.at("w")->fld.data(),
+                advec_flux.fld.data(), fld.fld.data(), w.fld.data(),
                 gd.istart, gd.iend, gd.jstart, gd.jend, gd.kstart, gd.kend,
                 gd.icells, gd.ijcells);
     }
@@ -1068,12 +1068,12 @@ void Advec_2i5<TF>::get_advec_flux(
     {
         if (std::find(sp_limit.begin(), sp_limit.end(), fld.name) != sp_limit.end())
             advec_flux_s_lim(
-                    advec_flux.fld.data(), fld.fld.data(), fields.mp.at("w")->fld.data(),
+                    advec_flux.fld.data(), fld.fld.data(), w.fld.data(),
                     gd.istart, gd.iend, gd.jstart, gd.jend, gd.kstart, gd.kend,
                     gd.icells, gd.ijcells);
         else
             advec_flux_s(
-                    advec_flux.fld.data(), fld.fld.data(), fields.mp.at("w")->fld.data(),
+                    advec_flux.fld.data(), fld.fld.data(), w.fld.data(),
                     gd.istart, gd.iend, gd.jstart, gd.jend, gd.kstart, gd.kend,
                     gd.icells, gd.ijcells);
     }

--- a/src/advec_2i53.cxx
+++ b/src/advec_2i53.cxx
@@ -825,7 +825,8 @@ void Advec_2i53<TF>::exec(Stats<TF>& stats)
 #endif
 
 template<typename TF>
-void Advec_2i53<TF>::get_advec_flux(Field3d<TF>& advec_flux, const Field3d<TF>& fld)
+void Advec_2i53<TF>::get_advec_flux(
+        Field3d<TF>& advec_flux, const Field3d<TF>& fld, const Field3d<TF>& w)
 {
     auto& gd = grid.get_grid_data();
 

--- a/src/advec_2i53.cxx
+++ b/src/advec_2i53.cxx
@@ -833,21 +833,21 @@ void Advec_2i53<TF>::get_advec_flux(
     if (fld.loc == gd.uloc)
     {
         advec_flux_u(
-                advec_flux.fld.data(), fld.fld.data(), fields.mp.at("w")->fld.data(),
+                advec_flux.fld.data(), fld.fld.data(), w.fld.data(),
                 gd.istart, gd.iend, gd.jstart, gd.jend, gd.kstart, gd.kend,
                 gd.icells, gd.ijcells);
     }
     else if (fld.loc == gd.vloc)
     {
         advec_flux_v(
-                advec_flux.fld.data(), fld.fld.data(), fields.mp.at("w")->fld.data(),
+                advec_flux.fld.data(), fld.fld.data(), w.fld.data(),
                 gd.istart, gd.iend, gd.jstart, gd.jend, gd.kstart, gd.kend,
                 gd.icells, gd.ijcells);
     }
     else if (fld.loc == gd.sloc)
     {
         advec_flux_s(
-                advec_flux.fld.data(), fld.fld.data(), fields.mp.at("w")->fld.data(),
+                advec_flux.fld.data(), fld.fld.data(), w.fld.data(),
                 gd.istart, gd.iend, gd.jstart, gd.jend, gd.kstart, gd.kend,
                 gd.icells, gd.ijcells);
     }

--- a/src/advec_2i62.cxx
+++ b/src/advec_2i62.cxx
@@ -489,7 +489,8 @@ void Advec_2i62<TF>::exec(Stats<TF>& stats)
 #endif
 
 template<typename TF>
-void Advec_2i62<TF>::get_advec_flux(Field3d<TF>& advec_flux, const Field3d<TF>& fld)
+void Advec_2i62<TF>::get_advec_flux(
+        Field3d<TF>& advec_flux, const Field3d<TF>& fld, const Field3d<TF>& w)
 {
     auto& gd = grid.get_grid_data();
 

--- a/src/advec_2i62.cxx
+++ b/src/advec_2i62.cxx
@@ -497,14 +497,14 @@ void Advec_2i62<TF>::get_advec_flux(
     if (fld.loc == gd.uloc)
     {
         advec_flux_u(
-                advec_flux.fld.data(), fld.fld.data(), fields.mp.at("w")->fld.data(),
+                advec_flux.fld.data(), fld.fld.data(), w.fld.data(),
                 gd.istart, gd.iend, gd.jstart, gd.jend, gd.kstart, gd.kend,
                 gd.icells, gd.ijcells);
     }
     else if (fld.loc == gd.vloc)
     {
         advec_flux_v(
-                advec_flux.fld.data(), fld.fld.data(), fields.mp.at("w")->fld.data(),
+                advec_flux.fld.data(), fld.fld.data(), w.fld.data(),
                 gd.istart, gd.iend, gd.jstart, gd.jend, gd.kstart, gd.kend,
                 gd.icells, gd.ijcells);
     }
@@ -512,12 +512,12 @@ void Advec_2i62<TF>::get_advec_flux(
     {
         if (std::find(sp_limit.begin(), sp_limit.end(), fld.name) != sp_limit.end())
             advec_flux_s_lim(
-                    advec_flux.fld.data(), fld.fld.data(), fields.mp.at("w")->fld.data(),
+                    advec_flux.fld.data(), fld.fld.data(), w.fld.data(),
                     gd.istart, gd.iend, gd.jstart, gd.jend, gd.kstart, gd.kend,
                     gd.icells, gd.ijcells);
         else
             advec_flux_s(
-                    advec_flux.fld.data(), fld.fld.data(), fields.mp.at("w")->fld.data(),
+                    advec_flux.fld.data(), fld.fld.data(), w.fld.data(),
                     gd.istart, gd.iend, gd.jstart, gd.jend, gd.kstart, gd.kend,
                     gd.icells, gd.ijcells);
     }

--- a/src/advec_4.cxx
+++ b/src/advec_4.cxx
@@ -665,7 +665,8 @@ void Advec_4<TF>::exec(Stats<TF>& stats)
 #endif
 
 template<typename TF>
-void Advec_4<TF>::get_advec_flux(Field3d<TF>& advec_flux, const Field3d<TF>& fld)
+void Advec_4<TF>::get_advec_flux(
+        Field3d<TF>& advec_flux, const Field3d<TF>& fld, const Field3d<TF>& w)
 {
     auto& gd = grid.get_grid_data();
 

--- a/src/advec_4.cxx
+++ b/src/advec_4.cxx
@@ -673,21 +673,21 @@ void Advec_4<TF>::get_advec_flux(
     if (fld.loc == gd.uloc)
     {
         advec_flux_u(
-                advec_flux.fld.data(), fld.fld.data(), fields.mp.at("w")->fld.data(),
+                advec_flux.fld.data(), fld.fld.data(), w.fld.data(),
                 gd.istart, gd.iend, gd.jstart, gd.jend, gd.kstart, gd.kend,
                 gd.icells, gd.ijcells);
     }
     else if (fld.loc == gd.vloc)
     {
         advec_flux_v(
-                advec_flux.fld.data(), fld.fld.data(), fields.mp.at("w")->fld.data(),
+                advec_flux.fld.data(), fld.fld.data(), w.fld.data(),
                 gd.istart, gd.iend, gd.jstart, gd.jend, gd.kstart, gd.kend,
                 gd.icells, gd.ijcells);
     }
     else if (fld.loc == gd.sloc)
     {
         advec_flux_s(
-                advec_flux.fld.data(), fld.fld.data(), fields.mp.at("w")->fld.data(),
+                advec_flux.fld.data(), fld.fld.data(), w.fld.data(),
                 gd.istart, gd.iend, gd.jstart, gd.jend, gd.kstart, gd.kend,
                 gd.icells, gd.ijcells);
     }

--- a/src/advec_4m.cxx
+++ b/src/advec_4m.cxx
@@ -596,7 +596,8 @@ void Advec_4m<TF>::exec(Stats<TF>& stats)
 #endif
 
 template<typename TF>
-void Advec_4m<TF>::get_advec_flux(Field3d<TF>& advec_flux, const Field3d<TF>& fld)
+void Advec_4m<TF>::get_advec_flux(
+        Field3d<TF>& advec_flux, const Field3d<TF>& fld, const Field3d<TF>& w)
 {
     auto& gd = grid.get_grid_data();
 

--- a/src/advec_4m.cxx
+++ b/src/advec_4m.cxx
@@ -604,21 +604,21 @@ void Advec_4m<TF>::get_advec_flux(
     if (fld.loc == gd.uloc)
     {
         advec_flux_u(
-                advec_flux.fld.data(), fld.fld.data(), fields.mp.at("w")->fld.data(),
+                advec_flux.fld.data(), fld.fld.data(), w.fld.data(),
                 gd.istart, gd.iend, gd.jstart, gd.jend, gd.kstart, gd.kend,
                 gd.icells, gd.ijcells);
     }
     else if (fld.loc == gd.vloc)
     {
         advec_flux_v(
-                advec_flux.fld.data(), fld.fld.data(), fields.mp.at("w")->fld.data(),
+                advec_flux.fld.data(), fld.fld.data(), w.fld.data(),
                 gd.istart, gd.iend, gd.jstart, gd.jend, gd.kstart, gd.kend,
                 gd.icells, gd.ijcells);
     }
     else if (fld.loc == gd.sloc)
     {
         advec_flux_s(
-                advec_flux.fld.data(), fld.fld.data(), fields.mp.at("w")->fld.data(),
+                advec_flux.fld.data(), fld.fld.data(), w.fld.data(),
                 gd.istart, gd.iend, gd.jstart, gd.jend, gd.kstart, gd.kend,
                 gd.icells, gd.ijcells);
     }

--- a/src/advec_disabled.cxx
+++ b/src/advec_disabled.cxx
@@ -59,7 +59,8 @@ template<typename TF>
 void Advec_disabled<TF>::exec(Stats<TF>&) {}
 
 template<typename TF>
-void Advec_disabled<TF>::get_advec_flux(Field3d<TF>& advec_flux, const Field3d<TF>& fld)
+void Advec_disabled<TF>::get_advec_flux(
+        Field3d<TF>& advec_flux, const Field3d<TF>& fld, const Field3d<TF>& w)
 {
     std::fill(advec_flux.fld.begin(), advec_flux.fld.end(), TF(0.));
 }

--- a/src/stats.cxx
+++ b/src/stats.cxx
@@ -1361,8 +1361,16 @@ void Stats<TF>::calc_mask_stats(
     if (std::find(varlist.begin(), varlist.end(), varname) != varlist.end())
     {
         set_flag(flag, nmask, m.second, fld.loc[2]);
-        calc_mean(m.second.profs.at(varname).data.data(), fld.fld.data(), mfield.data(), flag, nmask,
-                gd.istart, gd.iend, gd.jstart, gd.jend, gd.kstart, gd.kend, gd.icells, gd.ijcells);
+
+        calc_mean(
+                m.second.profs.at(varname).data.data(),
+                fld.fld.data(),
+                mfield.data(), flag, nmask,
+                gd.istart, gd.iend,
+                gd.jstart, gd.jend,
+                gd.kstart, gd.kend,
+                gd.icells, gd.ijcells);
+
         master.sum(m.second.profs.at(varname).data.data(), gd.kcells);
 
         // Add the offset.
@@ -1379,10 +1387,15 @@ void Stats<TF>::calc_mask_stats(
         if (std::find(varlist.begin(), varlist.end(), name) != varlist.end())
         {
             set_flag(flag, nmask, m.second, fld.loc[2]);
+
             calc_moment(
-                    m.second.profs.at(name).data.data(), fld.fld.data(),
-                    m.second.profs.at(varname).data.data(), offset, mfield.data(), flag, nmask,
-                    power, gd.istart, gd.iend, gd.jstart, gd.jend, gd.kstart, gd.kend,
+                    m.second.profs.at(name).data.data(),
+                    fld.fld.data(),
+                    m.second.profs.at(varname).data.data(), offset,
+                    mfield.data(), flag, nmask, power,
+                    gd.istart, gd.iend,
+                    gd.jstart, gd.jend,
+                    gd.kstart, gd.kend,
                     gd.icells, gd.ijcells);
 
             master.sum(m.second.profs.at(name).data.data(), gd.kcells);
@@ -1395,18 +1408,60 @@ void Stats<TF>::calc_mask_stats(
     if (std::find(varlist.begin(), varlist.end(), name) != varlist.end())
     {
         auto advec_flux = fields.get_tmp();
-        //advec.get_advec_flux(*advec_flux, fld);
+        auto fld_prime = fields.get_tmp();
+        auto w_prime = fields.get_tmp();
+
+        // Set flag for `w` level, and calculate `w_mean` over mask in `w_prime->fld_mean`.
+        const int w_loc = 1;
+        set_flag(flag, nmask, m.second, w_loc);
+
+        calc_mean(
+                w_prime->fld_mean.data(),
+                fields.mp.at("w")->fld.data(),
+                mfield.data(), flag, nmask,
+                gd.istart, gd.iend,
+                gd.jstart, gd.jend,
+                gd.kstart, gd.kend,
+                gd.icells, gd.ijcells);
+
+        // Subtract mean from `var` and `w` to get turbulent fluctuations.
+        subtract_mean(
+                fld_prime->fld.data(),
+                fld.fld.data(),
+                m.second.profs.at(varname).data.data(),
+                gd.istart, gd.iend,
+                gd.jstart, gd.jend,
+                gd.kstart, gd.kend,
+                gd.icells, gd.ijcells);
+
+        subtract_mean(
+                w_prime->fld.data(),
+                fields.mp.at("w")->fld.data(),
+                w_prime->fld_mean.data(),
+                gd.istart, gd.iend,
+                gd.jstart, gd.jend,
+                gd.kstart, gd.kend+1,
+                gd.icells, gd.ijcells);
+
+        advec.get_advec_flux(*advec_flux, *fld_prime, *w_prime);
 
         set_flag(flag, nmask, m.second, !fld.loc[2]);
+
         calc_mean(
-                m.second.profs.at(name).data.data(), advec_flux->fld.data(), mfield.data(), flag, nmask,
-                gd.istart, gd.iend, gd.jstart, gd.jend, gd.kstart, gd.kend,
+                m.second.profs.at(name).data.data(),
+                advec_flux->fld.data(),
+                mfield.data(), flag, nmask,
+                gd.istart, gd.iend,
+                gd.jstart, gd.jend,
+                gd.kstart, gd.kend,
                 gd.icells, gd.ijcells);
 
         master.sum(m.second.profs.at(name).data.data(), gd.kcells);
         set_fillvalue_prof(m.second.profs.at(name).data.data(), nmask, gd.kstart, gd.kcells);
 
         fields.release_tmp(advec_flux);
+        fields.release_tmp(fld_prime);
+        fields.release_tmp(w_prime);
     }
 
     // Calc Diffusive Flux
@@ -1417,9 +1472,14 @@ void Stats<TF>::calc_mask_stats(
         diff.diff_flux(*diff_flux, fld);
 
         set_flag(flag, nmask, m.second, !fld.loc[2]);
+
         calc_mean(
-                m.second.profs.at(name).data.data(), diff_flux->fld.data(), mfield.data(), flag, nmask,
-                gd.istart, gd.iend, gd.jstart, gd.jend, gd.kstart, gd.kend,
+                m.second.profs.at(name).data.data(),
+                diff_flux->fld.data(),
+                mfield.data(), flag, nmask,
+                gd.istart, gd.iend,
+                gd.jstart, gd.jend,
+                gd.kstart, gd.kend,
                 gd.icells, gd.ijcells);
 
         master.sum(m.second.profs.at(name).data.data(), gd.kcells);
@@ -1434,9 +1494,13 @@ void Stats<TF>::calc_mask_stats(
     {
         // No sum is required in this routine as values all.
         set_flag(flag, nmask, m.second, !fld.loc[2]);
+
         add_fluxes(
-                m.second.profs.at(name).data.data(), m.second.profs.at(varname+"_w").data.data(), m.second.profs.at(varname+"_diff").data.data(),
+                m.second.profs.at(name).data.data(),
+                m.second.profs.at(varname+"_w").data.data(),
+                m.second.profs.at(varname+"_diff").data.data(),
                 gd.kstart, gd.kend);
+
         set_fillvalue_prof(m.second.profs.at(name).data.data(), nmask, gd.kstart, gd.kcells);
     }
 
@@ -1449,15 +1513,23 @@ void Stats<TF>::calc_mask_stats(
         if (grid.get_spatial_order() == Grid_order::Second)
         {
             calc_grad_2nd(
-                    m.second.profs.at(name).data.data(), fld.fld.data(), gd.dzhi.data(), mfield.data(), flag, nmask,
-                    gd.istart, gd.iend, gd.jstart, gd.jend, gd.kstart, gd.kend,
+                    m.second.profs.at(name).data.data(),
+                    fld.fld.data(), gd.dzhi.data(),
+                    mfield.data(), flag, nmask,
+                    gd.istart, gd.iend,
+                    gd.jstart, gd.jend,
+                    gd.kstart, gd.kend,
                     gd.icells, gd.ijcells);
         }
         else if (grid.get_spatial_order() == Grid_order::Fourth)
         {
             calc_grad_4th(
-                    m.second.profs.at(name).data.data(), fld.fld.data(), gd.dzhi4.data(), mfield.data(), flag, nmask,
-                    gd.istart, gd.iend, gd.jstart, gd.jend, gd.kstart, gd.kend,
+                    m.second.profs.at(name).data.data(),
+                    fld.fld.data(), gd.dzhi4.data(),
+                    mfield.data(), flag, nmask,
+                    gd.istart, gd.iend,
+                    gd.jstart, gd.jend,
+                    gd.kstart, gd.kend,
                     gd.icells, gd.ijcells);
         }
 
@@ -1472,9 +1544,12 @@ void Stats<TF>::calc_mask_stats(
         set_flag(flag, nmask, m.second, fld.loc[2]);
 
         std::pair<TF, int> path = calc_path(
-                fld.fld.data(), gd.dz.data(), fields.rhoref.data(),
+                fld.fld.data(), gd.dz.data(),
+                fields.rhoref.data(),
                 mfield.data(), flag, nmask,
-                gd.istart, gd.iend, gd.jstart, gd.jend, gd.kstart, gd.kend,
+                gd.istart, gd.iend,
+                gd.jstart, gd.jend,
+                gd.kstart, gd.kend,
                 gd.icells, gd.ijcells);
 
         master.sum(&path.first, 1);
@@ -1491,8 +1566,11 @@ void Stats<TF>::calc_mask_stats(
 
         // Function returns number of poinst covered (cover.first) and number of points in mask (cover.second).
         std::pair<int, int> cover = calc_cover(
-                fld.fld.data(), offset, threshold, mfield.data(), flag, nmask,
-                gd.istart, gd.iend, gd.jstart, gd.jend, gd.kstart, gd.kend,
+                fld.fld.data(), offset, threshold,
+                mfield.data(), flag, nmask,
+                gd.istart, gd.iend,
+                gd.jstart, gd.jend,
+                gd.kstart, gd.kend,
                 gd.icells, gd.ijcells);
 
         master.sum(&cover.first, 1);
@@ -1510,9 +1588,13 @@ void Stats<TF>::calc_mask_stats(
         set_flag(flag, nmask, m.second, fld.loc[2]);
 
         calc_frac(
-                m.second.profs.at(name).data.data(), fld.fld.data(),
-                offset, threshold, mfield.data(), flag, nmask,
-                gd.istart, gd.iend, gd.jstart, gd.jend, gd.kstart, gd.kend,
+                m.second.profs.at(name).data.data(),
+                fld.fld.data(),
+                offset, threshold,
+                mfield.data(), flag, nmask,
+                gd.istart, gd.iend,
+                gd.jstart, gd.jend,
+                gd.kstart, gd.kend,
                 gd.icells, gd.ijcells);
 
         master.sum(m.second.profs.at(name).data.data(), gd.kcells);

--- a/src/stats.cxx
+++ b/src/stats.cxx
@@ -510,7 +510,29 @@ namespace
     {
         return s.find_first_not_of( "23456789" ) == std::string::npos;
     }
+
+    template<typename TF>
+    void subtract_mean(
+            TF* const restrict fld_prime,
+            const TF* const restrict fld,
+            const TF* const restrict fld_mean,
+            const int istart, const int iend,
+            const int jstart, const int jend,
+            const int kstart, const int kend,
+            const int icells, const int ijcells)
+    {
+        #pragma omp parallel for
+        for (int k=kstart; k<kend; ++k)
+            for (int j=jstart; j<jend; ++j)
+                #pragma ivdep
+                for (int i=istart; i<iend; ++i)
+                {
+                    const int ijk = i + j*icells + k*ijcells;
+                    fld_prime[ijk] = fld[ijk] - fld_mean[k];
+                }
+    }
 }
+
 
 template<typename TF>
 Stats<TF>::Stats(
@@ -1373,7 +1395,7 @@ void Stats<TF>::calc_mask_stats(
     if (std::find(varlist.begin(), varlist.end(), name) != varlist.end())
     {
         auto advec_flux = fields.get_tmp();
-        advec.get_advec_flux(*advec_flux, fld);
+        //advec.get_advec_flux(*advec_flux, fld);
 
         set_flag(flag, nmask, m.second, !fld.loc[2]);
         calc_mean(
@@ -1514,8 +1536,15 @@ void Stats<TF>::calc_stats(
         for (auto& m : masks)
         {
             set_flag(flag, nmask, m.second, fld.loc[2]);
-            calc_mean(m.second.profs.at(varname).data.data(), fld.fld.data(), mfield.data(), flag, nmask,
-                    gd.istart, gd.iend, gd.jstart, gd.jend, gd.kstart, gd.kend, gd.icells, gd.ijcells);
+
+            calc_mean(
+                    m.second.profs.at(varname).data.data(),
+                    fld.fld.data(),
+                    mfield.data(), flag, nmask,
+                    gd.istart, gd.iend,
+                    gd.jstart, gd.jend,
+                    gd.kstart, gd.kend,
+                    gd.icells, gd.ijcells);
             master.sum(m.second.profs.at(varname).data.data(), gd.kcells);
 
             // Add the offset.
@@ -1535,10 +1564,15 @@ void Stats<TF>::calc_stats(
             for (auto& m : masks)
             {
                 set_flag(flag, nmask, m.second, fld.loc[2]);
+
                 calc_moment(
-                        m.second.profs.at(name).data.data(), fld.fld.data(),
-                        m.second.profs.at(varname).data.data(), offset, mfield.data(), flag, nmask,
-                        power, gd.istart, gd.iend, gd.jstart, gd.jend, gd.kstart, gd.kend,
+                        m.second.profs.at(name).data.data(),
+                        fld.fld.data(),
+                        m.second.profs.at(varname).data.data(),
+                        offset, mfield.data(), flag, nmask, power,
+                        gd.istart, gd.iend,
+                        gd.jstart, gd.jend,
+                        gd.kstart, gd.kend,
                         gd.icells, gd.ijcells);
 
                 master.sum(m.second.profs.at(name).data.data(), gd.kcells);
@@ -1552,20 +1586,64 @@ void Stats<TF>::calc_stats(
     if (std::find(varlist.begin(), varlist.end(), name) != varlist.end())
     {
         auto advec_flux = fields.get_tmp();
-        advec.get_advec_flux(*advec_flux, fld);
+        auto fld_prime = fields.get_tmp();
+        auto w_prime = fields.get_tmp();
 
         for (auto& m : masks)
         {
-            set_flag(flag, nmask, m.second, !fld.loc[2]);
+            // Set flag for `w` level, and calculate `w_mean` over mask in `w_prime->fld_mean`.
+            const int w_loc = 1;
+            set_flag(flag, nmask, m.second, w_loc);
+
             calc_mean(
-                    m.second.profs.at(name).data.data(), advec_flux->fld.data(), mfield.data(), flag, nmask,
-                    gd.istart, gd.iend, gd.jstart, gd.jend, gd.kstart, gd.kend,
+                    w_prime->fld_mean.data(),
+                    fields.mp.at("w")->fld.data(),
+                    mfield.data(), flag, nmask,
+                    gd.istart, gd.iend,
+                    gd.jstart, gd.jend,
+                    gd.kstart, gd.kend,
+                    gd.icells, gd.ijcells);
+
+            // Subtract mean from `var` and `w` to get turbulent fluctuations.
+            subtract_mean(
+                    fld_prime->fld.data(),
+                    fld.fld.data(),
+                    m.second.profs.at(varname).data.data(),
+                    gd.istart, gd.iend,
+                    gd.jstart, gd.jend,
+                    gd.kstart, gd.kend,
+                    gd.icells, gd.ijcells);
+
+            subtract_mean(
+                    w_prime->fld.data(),
+                    fields.mp.at("w")->fld.data(),
+                    w_prime->fld_mean.data(),
+                    gd.istart, gd.iend,
+                    gd.jstart, gd.jend,
+                    gd.kstart, gd.kend+1,
+                    gd.icells, gd.ijcells);
+
+            advec.get_advec_flux(*advec_flux, *fld_prime, *w_prime);
+
+            // Switch flag to flux location of `fld`.
+            set_flag(flag, nmask, m.second, !fld.loc[2]);
+
+            calc_mean(
+                    m.second.profs.at(name).data.data(),
+                    advec_flux->fld.data(),
+                    mfield.data(), flag, nmask,
+                    gd.istart, gd.iend,
+                    gd.jstart, gd.jend,
+                    gd.kstart, gd.kend,
                     gd.icells, gd.ijcells);
 
             master.sum(m.second.profs.at(name).data.data(), gd.kcells);
             set_fillvalue_prof(m.second.profs.at(name).data.data(), nmask, gd.kstart, gd.kcells);
         }
+
         fields.release_tmp(advec_flux);
+        fields.release_tmp(fld_prime);
+        fields.release_tmp(w_prime);
     }
 
     // Calc Diffusive Flux
@@ -1578,9 +1656,14 @@ void Stats<TF>::calc_stats(
         for (auto& m : masks)
         {
             set_flag(flag, nmask, m.second, !fld.loc[2]);
+
             calc_mean(
-                    m.second.profs.at(name).data.data(), diff_flux->fld.data(), mfield.data(), flag, nmask,
-                    gd.istart, gd.iend, gd.jstart, gd.jend, gd.kstart, gd.kend,
+                    m.second.profs.at(name).data.data(),
+                    diff_flux->fld.data(),
+                    mfield.data(), flag, nmask,
+                    gd.istart, gd.iend,
+                    gd.jstart, gd.jend,
+                    gd.kstart, gd.kend,
                     gd.icells, gd.ijcells);
 
             master.sum(m.second.profs.at(name).data.data(), gd.kcells);
@@ -1598,10 +1681,13 @@ void Stats<TF>::calc_stats(
         {
             // No sum is required in this routine as values all.
             set_flag(flag, nmask, m.second, !fld.loc[2]);
+
             add_fluxes(
-                    m.second.profs.at(name).data.data(), m.second.profs.at(varname+"_w").data.data(),
+                    m.second.profs.at(name).data.data(),
+                    m.second.profs.at(varname+"_w").data.data(),
                     m.second.profs.at(varname+"_diff").data.data(),
                     gd.kstart, gd.kend);
+
             set_fillvalue_prof(m.second.profs.at(name).data.data(), nmask, gd.kstart, gd.kcells);
         }
     }
@@ -1617,15 +1703,23 @@ void Stats<TF>::calc_stats(
             if (grid.get_spatial_order() == Grid_order::Second)
             {
                 calc_grad_2nd(
-                        m.second.profs.at(name).data.data(), fld.fld.data(), gd.dzhi.data(), mfield.data(), flag, nmask,
-                        gd.istart, gd.iend, gd.jstart, gd.jend, gd.kstart, gd.kend,
+                        m.second.profs.at(name).data.data(),
+                        fld.fld.data(), gd.dzhi.data(),
+                        mfield.data(), flag, nmask,
+                        gd.istart, gd.iend,
+                        gd.jstart, gd.jend,
+                        gd.kstart, gd.kend,
                         gd.icells, gd.ijcells);
             }
             else if (grid.get_spatial_order() == Grid_order::Fourth)
             {
                 calc_grad_4th(
-                        m.second.profs.at(name).data.data(), fld.fld.data(), gd.dzhi4.data(), mfield.data(), flag, nmask,
-                        gd.istart, gd.iend, gd.jstart, gd.jend, gd.kstart, gd.kend,
+                        m.second.profs.at(name).data.data(),
+                        fld.fld.data(), gd.dzhi4.data(),
+                        mfield.data(), flag, nmask,
+                        gd.istart, gd.iend,
+                        gd.jstart, gd.jend,
+                        gd.kstart, gd.kend,
                         gd.icells, gd.ijcells);
             }
 
@@ -1643,9 +1737,12 @@ void Stats<TF>::calc_stats(
             set_flag(flag, nmask, m.second, fld.loc[2]);
 
             std::pair<TF, int> path = calc_path(
-                    fld.fld.data(), gd.dz.data(), fields.rhoref.data(),
+                    fld.fld.data(), gd.dz.data(),
+                    fields.rhoref.data(),
                     mfield.data(), flag, nmask,
-                    gd.istart, gd.iend, gd.jstart, gd.jend, gd.kstart, gd.kend,
+                    gd.istart, gd.iend,
+                    gd.jstart, gd.jend,
+                    gd.kstart, gd.kend,
                     gd.icells, gd.ijcells);
 
             master.sum(&path.first, 1);
@@ -1665,8 +1762,12 @@ void Stats<TF>::calc_stats(
 
             // Function returns number of poinst covered (cover.first) and number of points in mask (cover.second).
             std::pair<int, int> cover = calc_cover(
-                    fld.fld.data(), offset, threshold, mfield.data(), flag, nmask,
-                    gd.istart, gd.iend, gd.jstart, gd.jend, gd.kstart, gd.kend,
+                    fld.fld.data(),
+                    offset, threshold,
+                    mfield.data(), flag, nmask,
+                    gd.istart, gd.iend,
+                    gd.jstart, gd.jend,
+                    gd.kstart, gd.kend,
                     gd.icells, gd.ijcells);
 
             master.sum(&cover.first, 1);
@@ -1687,8 +1788,13 @@ void Stats<TF>::calc_stats(
             set_flag(flag, nmask, m.second, fld.loc[2]);
 
             calc_frac(
-                    m.second.profs.at(name).data.data(), fld.fld.data(), offset, threshold, mfield.data(), flag, nmask,
-                    gd.istart, gd.iend, gd.jstart, gd.jend, gd.kstart, gd.kend,
+                    m.second.profs.at(name).data.data(),
+                    fld.fld.data(),
+                    offset, threshold,
+                    mfield.data(), flag, nmask,
+                    gd.istart, gd.iend,
+                    gd.jstart, gd.jend,
+                    gd.kstart, gd.kend,
                     gd.icells, gd.ijcells);
 
             master.sum(m.second.profs.at(name).data.data(), gd.kcells);

--- a/src/stats.cxx
+++ b/src/stats.cxx
@@ -1424,6 +1424,8 @@ void Stats<TF>::calc_mask_stats(
                 gd.kstart, gd.kend,
                 gd.icells, gd.ijcells);
 
+        master.sum(w_prime->fld_mean.data(), gd.kcells);
+
         // Subtract mean from `var` and `w` to get turbulent fluctuations.
         subtract_mean(
                 fld_prime->fld.data(),
@@ -1685,6 +1687,8 @@ void Stats<TF>::calc_stats(
                     gd.jstart, gd.jend,
                     gd.kstart, gd.kend,
                     gd.icells, gd.ijcells);
+
+            master.sum(w_prime->fld_mean.data(), gd.kcells);
 
             // Subtract mean from `var` and `w` to get turbulent fluctuations.
             subtract_mean(


### PR DESCRIPTION
The old `get_advec_flux` operated on the absolute fields (like in advection itself), not on the turbulent quantities. This gives strange values for the conditionally averaged statistics. This fix subtracts the mask averaged mean profiles from `w` and the statistics field itself, such that the fluxes calculated in `get_advec_flux` are `<w^prime x fld^prime>` instead of `<w x fld>`.