### PR TITLE
Fixed CUDA compilation

### DIFF
--- a/src/advec_2i53.cu
+++ b/src/advec_2i53.cu
@@ -40,19 +40,12 @@ unsigned long Advec_2i53<TF>::get_time_limit(unsigned long idt, double dt)
     throw std::runtime_error("Advec_2i53 is not (yet) implemented on the GPU");
 }
 
-
 template<typename TF>
 void Advec_2i53<TF>::exec(Stats<TF>& stats)
 {
     throw std::runtime_error("Advec_2i53 is not (yet) implemented on the GPU");
 }
 #endif
-
-template<typename TF>
-void Advec_2i53<TF>::get_advec_flux(Field3d<TF>& advec_flux, const Field3d<TF>& fld)
-{
-    throw std::runtime_error("Advec_2i53 is not (yet) implemented on the GPU");
-}
 
 template class Advec_2i53<double>;
 template class Advec_2i53<float>;


### PR DESCRIPTION
`get_advec_flux` is purely a statistics function, and should have never been defined in the CUDA advection code.

Tests:
- code compiles again on the CPU and GPU.
- `drycblles` with `2i53` advection on CPU works.
- `drycblles` with `2i53` advection on GPU throws "not implemented error".