### PR TITLE
Make CMake fixes to let generic work on mac as well.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -79,6 +79,7 @@ else()
   project(microhhc C CXX Fortran)
 endif()
 
+
 # Display status messages for MPI set precompiler flags.
 if(USEMPI)
   message(STATUS "MPI: Enabled.")

--- a/main/CMakeLists.txt
+++ b/main/CMakeLists.txt
@@ -19,7 +19,6 @@
 #  You should have received a copy of the GNU General Public License
 #  along with MicroHH.  If not, see <http://www.gnu.org/licenses/>.
 #
-include_directories(${INCLUDE_DIRS} "../include")
 
 # retrieve the git hash from the current commit
 find_package(Git)
@@ -38,6 +37,8 @@ message(STATUS "Git hash " ${GITHASH})
 add_definitions(-DGITHASH="${GITHASH}")
 
 add_executable(microhh microhh.cxx)
+target_include_directories(microhh PUBLIC ${INCLUDE_DIRS} "../include")
+
 if(USECUDA)
     target_link_libraries(microhh microhhc rte_rrtmgp rte_rrtmgp_cuda rte_rrtmgp_kernels rte_rrtmgp_kernels_cuda ${LIBS} m)
 else()

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -20,6 +20,6 @@
 #  along with MicroHH.  If not, see <http://www.gnu.org/licenses/>.
 #
 FILE(GLOB sourcefiles "../src/*.cxx" "../src/*.cu")
-include_directories("../include" "../rte-rrtmgp-cpp/include" "../rte-rrtmgp-cpp/include-kernels" "../rte-rrtmgp-cpp/include_kernels_cuda" SYSTEM ${INCLUDE_DIRS})
 
 add_library(microhhc STATIC ${sourcefiles})
+target_include_directories(microhhc PUBLIC "../include" "../rte-rrtmgp-cpp/include" "../rte-rrtmgp-cpp/include-kernels" "../rte-rrtmgp-cpp/include_kernels_cuda" ${INCLUDE_DIRS})


### PR DESCRIPTION
@thijsheus Please have a look, if I use `target_include_directories` as now seems the standard, it all works well.