### PR TITLE
Date/time bugfix, missing includes, and submodule version

### DIFF
--- a/include/thermo_buoy.h
+++ b/include/thermo_buoy.h
@@ -23,6 +23,7 @@
 #ifndef THERMO_BUOY_H
 #define THERMO_BUOY_H
 
+#include <stdexcept>
 #include "thermo.h"
 
 class Master;

--- a/include/thermo_disabled.h
+++ b/include/thermo_disabled.h
@@ -23,6 +23,7 @@
 #ifndef THERMO_DISABLED_H
 #define THERMO_DISABLED_H
 
+#include <stdexcept>
 #include "thermo.h"
 
 class Master;

--- a/include/thermo_dry.h
+++ b/include/thermo_dry.h
@@ -23,6 +23,8 @@
 #ifndef THERMO_DRY_H
 #define THERMO_DRY_H
 
+#include <stdexcept>
+
 #include "boundary_cyclic.h"
 #include "timedep.h"
 #include "thermo.h"

--- a/include/thermo_vapor.h
+++ b/include/thermo_vapor.h
@@ -23,6 +23,8 @@
 #ifndef THERMO_VAPOR_H
 #define THERMO_VAPOR_H
 
+#include <stdexcept>
+
 #include "boundary_cyclic.h"
 #include "timedep.h"
 #include "thermo.h"

--- a/src/cross.cxx
+++ b/src/cross.cxx
@@ -24,6 +24,8 @@
 #include <cstdlib>
 #include <cmath>
 #include <algorithm>    // std::count
+#include <stdexcept>
+
 #include "master.h"
 #include "grid.h"
 #include "soil_grid.h"

--- a/src/microphys.cxx
+++ b/src/microphys.cxx
@@ -20,6 +20,8 @@
  * along with MicroHH.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+#include <stdexcept>
+
 #include "master.h"
 #include "grid.h"
 #include "fields.h"

--- a/src/radiation.cxx
+++ b/src/radiation.cxx
@@ -23,6 +23,7 @@
 #include <cstdio>
 #include <cmath>
 #include <algorithm>
+#include <stdexcept>
 
 #include "master.h"
 #include "input.h"

--- a/src/radiation_disabled.cxx
+++ b/src/radiation_disabled.cxx
@@ -19,6 +19,8 @@
  * along with MicroHH.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+#include <stdexcept>
+
 #include "radiation_disabled.h"
 #include "constants.h"
 

--- a/src/radiation_rrtmgp.cxx
+++ b/src/radiation_rrtmgp.cxx
@@ -22,6 +22,7 @@
 #include <numeric>
 #include <string>
 #include <cmath>
+#include <stdexcept>
 
 #include "radiation_rrtmgp.h"
 #include "radiation_rrtmgp_functions.h"

--- a/src/timeloop.cxx
+++ b/src/timeloop.cxx
@@ -75,6 +75,11 @@ Timeloop<TF>::Timeloop(
     {
         flag_utc_time = true;
         strptime(datetime_utc_string.c_str(), "%Y-%m-%d %H:%M:%S", &tm_utc_start);
+
+        // NOTE: the following fields are NOT set by `strptime()`, which can lead to undefined behaviour.
+        tm_utc_start.tm_isdst = 0;      // no daylight saving offset.
+        tm_utc_start.tm_gmtoff = 0;     // no offset from UTC.
+        tm_utc_start.tm_zone = "utc";   // time zone = UTC.
     }
 
     if (sim_mode == Sim_mode::Post)


### PR DESCRIPTION
The main change is a bugfix in our date/time bookkeeping; the problem is that `strptime(..., &tm_struct)` leaves a number of variables in `tm_struct` undefined, which could cause a +/- 0/1 hour offset on random MPI tasks. I'm not entirely sure why this worked correctly before: on some systems, it seems that at least `tm_gmtoff` was the same on all MPI tasks... This fix explicitly initializes all variables left undefined by `strptime()`.

The other commits are simply missing includes, and an update of the RRTMGP submodule.