### PR TITLE
Don't allow `post` mode on the GPU.

### DIFF
--- a/src/model.cxx
+++ b/src/model.cxx
@@ -108,6 +108,11 @@ Model<TF>::Model(Master& masterin, int argc, char *argv[]) :
 {
     process_command_line_options(sim_mode, sim_name, argc, argv, master);
 
+    #ifdef USECUDA
+    if (sim_mode == Sim_mode::Post)
+        throw std::runtime_error("\"post\" mode is not supported on the GPU!");
+    #endif
+
     input = std::make_shared<Input>(master, sim_name + ".ini");
     input_nc = std::make_shared<Netcdf_file>(master, sim_name + "_input.nc", Netcdf_mode::Read);
 


### PR DESCRIPTION
`post` mode does not work correctly on the GPU. Since nearly all statistics are anyhow calculated on the CPU, it does not really make sense to run `post` mode on the GPU. Therefore, I suggest to just throw an error when `post` and CUDA are combined.