### PR TITLE
Issue 109 - Stat flux bug

### DIFF
--- a/src/advec_2.cxx
+++ b/src/advec_2.cxx
@@ -209,7 +209,7 @@ namespace
     {
         const int ii = 1;
 
-        for (int k=kstart; k<kend+1; ++k)
+        for (int k=kstart+1; k<kend; ++k)
             for (int j=jstart; j<jend; ++j)
                 #pragma ivdep
                 for (int i=istart; i<iend; ++i)
@@ -217,6 +217,15 @@ namespace
                     const int ijk = i + j*jj + k*kk;
                     st[ijk] = interp2(w[ijk-ii], w[ijk]) * interp2(s[ijk-kk], s[ijk]);
                 }
+        for (int j=jstart; j<jend; ++j)
+            #pragma ivdep
+            for (int i=istart; i<iend; ++i)
+            {
+                int ijk = i + j*jj + kstart*kk;
+                st[ijk] = 0;
+                ijk = i + j*jj + kend*kk;
+                st[ijk] = 0;
+            }
     }
 
     template<typename TF>
@@ -225,7 +234,7 @@ namespace
             const int istart, const int iend, const int jstart, const int jend, const int kstart, const int kend,
             const int jj, const int kk)
     {
-        for (int k=kstart; k<kend+1; ++k)
+        for (int k=kstart+1; k<kend; ++k)
             for (int j=jstart; j<jend; ++j)
                 #pragma ivdep
                 for (int i=istart; i<iend; ++i)
@@ -233,6 +242,16 @@ namespace
                     const int ijk = i + j*jj + k*kk;
                     st[ijk] = interp2(w[ijk-jj], w[ijk]) * interp2(s[ijk-kk], s[ijk]);
                 }
+        for (int j=jstart; j<jend; ++j)
+            #pragma ivdep
+            for (int i=istart; i<iend; ++i)
+            {
+                int ijk = i + j*jj + kstart*kk;
+                st[ijk] = 0;
+                ijk = i + j*jj + kend*kk;
+                st[ijk] = 0;
+            }
+
     }
 
     template<typename TF>
@@ -241,7 +260,7 @@ namespace
             const int istart, const int iend, const int jstart, const int jend, const int kstart, const int kend,
             const int jj, const int kk)
     {
-        for (int k=kstart; k<kend+1; ++k)
+        for (int k=kstart+1; k<kend; ++k)
             for (int j=jstart; j<jend; ++j)
                 #pragma ivdep
                 for (int i=istart; i<iend; ++i)
@@ -249,6 +268,15 @@ namespace
                     const int ijk = i + j*jj + k*kk;
                     st[ijk] = w[ijk] * interp2(s[ijk-kk], s[ijk]);
                 }
+        for (int j=jstart; j<jend; ++j)
+            #pragma ivdep
+            for (int i=istart; i<iend; ++i)
+            {
+                int ijk = i + j*jj + kstart*kk;
+                st[ijk] = 0;
+                ijk = i + j*jj + kend*kk;
+                st[ijk] = 0;
+            }
     }
 }
 

--- a/src/advec_2.cxx
+++ b/src/advec_2.cxx
@@ -209,7 +209,7 @@ namespace
     {
         const int ii = 1;
 
-        for (int k=kstart+1; k<kend; ++k)
+        for (int k=kstart; k<kend+1; ++k)
             for (int j=jstart; j<jend; ++j)
                 #pragma ivdep
                 for (int i=istart; i<iend; ++i)
@@ -217,15 +217,6 @@ namespace
                     const int ijk = i + j*jj + k*kk;
                     st[ijk] = interp2(w[ijk-ii], w[ijk]) * interp2(s[ijk-kk], s[ijk]);
                 }
-        for (int j=jstart; j<jend; ++j)
-            #pragma ivdep
-            for (int i=istart; i<iend; ++i)
-            {
-                int ijk = i + j*jj + kstart*kk;
-                st[ijk] = 0;
-                ijk = i + j*jj + kend*kk;
-                st[ijk] = 0;
-            }
     }
 
     template<typename TF>
@@ -234,7 +225,7 @@ namespace
             const int istart, const int iend, const int jstart, const int jend, const int kstart, const int kend,
             const int jj, const int kk)
     {
-        for (int k=kstart+1; k<kend; ++k)
+        for (int k=kstart; k<kend+1; ++k)
             for (int j=jstart; j<jend; ++j)
                 #pragma ivdep
                 for (int i=istart; i<iend; ++i)
@@ -242,16 +233,6 @@ namespace
                     const int ijk = i + j*jj + k*kk;
                     st[ijk] = interp2(w[ijk-jj], w[ijk]) * interp2(s[ijk-kk], s[ijk]);
                 }
-        for (int j=jstart; j<jend; ++j)
-            #pragma ivdep
-            for (int i=istart; i<iend; ++i)
-            {
-                int ijk = i + j*jj + kstart*kk;
-                st[ijk] = 0;
-                ijk = i + j*jj + kend*kk;
-                st[ijk] = 0;
-            }
-
     }
 
     template<typename TF>
@@ -260,7 +241,7 @@ namespace
             const int istart, const int iend, const int jstart, const int jend, const int kstart, const int kend,
             const int jj, const int kk)
     {
-        for (int k=kstart+1; k<kend; ++k)
+        for (int k=kstart; k<kend+1; ++k)
             for (int j=jstart; j<jend; ++j)
                 #pragma ivdep
                 for (int i=istart; i<iend; ++i)
@@ -268,15 +249,6 @@ namespace
                     const int ijk = i + j*jj + k*kk;
                     st[ijk] = w[ijk] * interp2(s[ijk-kk], s[ijk]);
                 }
-        for (int j=jstart; j<jend; ++j)
-            #pragma ivdep
-            for (int i=istart; i<iend; ++i)
-            {
-                int ijk = i + j*jj + kstart*kk;
-                st[ijk] = 0;
-                ijk = i + j*jj + kend*kk;
-                st[ijk] = 0;
-            }
     }
 }
 

--- a/src/stats.cxx
+++ b/src/stats.cxx
@@ -268,7 +268,7 @@ namespace
             const int icells, const int ijcells)
     {
         #pragma omp parallel for
-        for (int k=kstart; k<kend+1; ++k)
+        for (int k=kstart-1; k<kend+1; ++k)
         {
             if (nmask[k])
             {
@@ -522,7 +522,7 @@ namespace
             const int icells, const int ijcells)
     {
         #pragma omp parallel for
-        for (int k=kstart; k<kend; ++k)
+        for (int k=kstart-1; k<kend+1; ++k)
             for (int j=jstart; j<jend; ++j)
                 #pragma ivdep
                 for (int i=istart; i<iend; ++i)


### PR DESCRIPTION
Fixed the stat flux bug at the surface for advec_2; it seems like a buffer overflow read at the surface and the top; we may have gotten lucky for the no-mask situation. I couldn't quickly judge whether this issue plays for other advection schemes as well.

