### PR TITLE
Declaring several fread statements as (void) to get rid of warnings

### DIFF
--- a/src/field3d_io.cxx
+++ b/src/field3d_io.cxx
@@ -867,14 +867,14 @@ int Field3d_io<TF>::load_xy_slice(
 {
     auto& gd = grid.get_grid_data();
 
-    const int count = gd.imax*gd.jmax;
+    const unsigned int count = gd.imax*gd.jmax;
 
     FILE *pFile;
     pFile = fopen(filename, "rb");
     if (pFile == NULL)
         return 1;
-
-    (void)!fread(tmp, sizeof(TF), count, pFile);
+    if(fread(tmp, sizeof(TF), count, pFile) != count )
+        return 1;
     fclose(pFile);
 
     // Subtract the ghost cells in case of a pure 2d plane that does not have ghost cells.

--- a/src/field3d_io.cxx
+++ b/src/field3d_io.cxx
@@ -874,7 +874,7 @@ int Field3d_io<TF>::load_xy_slice(
     if (pFile == NULL)
         return 1;
 
-    fread(tmp, sizeof(TF), count, pFile);
+    (void)!fread(tmp, sizeof(TF), count, pFile);
     fclose(pFile);
 
     // Subtract the ghost cells in case of a pure 2d plane that does not have ghost cells.

--- a/src/field3d_io.cxx
+++ b/src/field3d_io.cxx
@@ -873,7 +873,7 @@ int Field3d_io<TF>::load_xy_slice(
     pFile = fopen(filename, "rb");
     if (pFile == NULL)
         return 1;
-    if(fread(tmp, sizeof(TF), count, pFile) != count )
+    if (fread(tmp, sizeof(TF), count, pFile) != count )
         return 1;
     fclose(pFile);
 

--- a/src/grid_parallel.cxx
+++ b/src/grid_parallel.cxx
@@ -164,8 +164,8 @@ void Grid<TF>::load_grid()
         {
             int n = (2*gd.itot+2*gd.jtot)*sizeof(TF);
             fseek(pFile, n, SEEK_SET);
-            fread(&gd.z [gd.kstart], sizeof(TF), gd.kmax, pFile);
-            fread(&gd.zh[gd.kstart], sizeof(TF), gd.kmax, pFile);
+            (void)!fread(&gd.z [gd.kstart], sizeof(TF), gd.kmax, pFile);
+            (void)!fread(&gd.zh[gd.kstart], sizeof(TF), gd.kmax, pFile);
             fclose(pFile);
         }
     }

--- a/src/grid_parallel.cxx
+++ b/src/grid_parallel.cxx
@@ -156,16 +156,16 @@ void Grid<TF>::load_grid()
     {
         pFile = fopen(filename, "rb");
         if (pFile == NULL)
-        {
-            master.print_message("FAILED\n");
             ++nerror;
-        }
         else
         {
             int n = (2*gd.itot+2*gd.jtot)*sizeof(TF);
-            fseek(pFile, n, SEEK_SET);
-            (void)!fread(&gd.z [gd.kstart], sizeof(TF), gd.kmax, pFile);
-            (void)!fread(&gd.zh[gd.kstart], sizeof(TF), gd.kmax, pFile);
+            if (fseek(pFile, n, SEEK_SET) != 0);
+                ++nerror;
+            if(fread(&gd.z [gd.kstart], sizeof(TF), gd.kmax, pFile) != (unsigned)gd.kmax )
+                ++nerror;
+            if(fread(&gd.zh[gd.kstart], sizeof(TF), gd.kmax, pFile) != (unsigned)gd.kmax )
+                ++nerror;
             fclose(pFile);
         }
     }

--- a/src/grid_parallel.cxx
+++ b/src/grid_parallel.cxx
@@ -160,11 +160,11 @@ void Grid<TF>::load_grid()
         else
         {
             int n = (2*gd.itot+2*gd.jtot)*sizeof(TF);
-            if (fseek(pFile, n, SEEK_SET) != 0);
+            if (fseek(pFile, n, SEEK_SET) != 0)
                 ++nerror;
-            if(fread(&gd.z [gd.kstart], sizeof(TF), gd.kmax, pFile) != (unsigned)gd.kmax )
+            if (fread(&gd.z [gd.kstart], sizeof(TF), gd.kmax, pFile) != (unsigned)gd.kmax )
                 ++nerror;
-            if(fread(&gd.zh[gd.kstart], sizeof(TF), gd.kmax, pFile) != (unsigned)gd.kmax )
+            if (fread(&gd.zh[gd.kstart], sizeof(TF), gd.kmax, pFile) != (unsigned)gd.kmax )
                 ++nerror;
             fclose(pFile);
         }

--- a/src/grid_serial.cxx
+++ b/src/grid_serial.cxx
@@ -98,12 +98,12 @@ void Grid<TF>::load_grid()
     if (nerror)
         throw std::runtime_error("Error in grid");
 
-    fread(&gd.x [gd.istart], sizeof(TF), gd.itot, pFile);
-    fread(&gd.xh[gd.istart], sizeof(TF), gd.itot, pFile);
-    fread(&gd.y [gd.jstart], sizeof(TF), gd.jtot, pFile);
-    fread(&gd.yh[gd.jstart], sizeof(TF), gd.jtot, pFile);
-    fread(&gd.z [gd.kstart], sizeof(TF), gd.ktot, pFile);
-    fread(&gd.zh[gd.kstart], sizeof(TF), gd.ktot, pFile);
+    (void)!fread(&gd.x [gd.istart], sizeof(TF), gd.itot, pFile);
+    (void)!fread(&gd.xh[gd.istart], sizeof(TF), gd.itot, pFile);
+    (void)!fread(&gd.y [gd.jstart], sizeof(TF), gd.jtot, pFile);
+    (void)!fread(&gd.yh[gd.jstart], sizeof(TF), gd.jtot, pFile);
+    (void)!fread(&gd.z [gd.kstart], sizeof(TF), gd.ktot, pFile);
+    (void)!fread(&gd.zh[gd.kstart], sizeof(TF), gd.ktot, pFile);
     fclose(pFile);
 
     // calculate the missing coordinates

--- a/src/grid_serial.cxx
+++ b/src/grid_serial.cxx
@@ -88,17 +88,17 @@ void Grid<TF>::load_grid()
     if (pFile == NULL)
         nerror++;
 
-    if(fread(&gd.x [gd.istart], sizeof(TF), gd.itot, pFile) != (unsigned)gd.itot )
+    if (fread(&gd.x [gd.istart], sizeof(TF), gd.itot, pFile) != (unsigned)gd.itot )
         ++nerror;
-    if(fread(&gd.xh[gd.istart], sizeof(TF), gd.itot, pFile) != (unsigned)gd.itot )
+    if (fread(&gd.xh[gd.istart], sizeof(TF), gd.itot, pFile) != (unsigned)gd.itot )
         ++nerror;
-    if(fread(&gd.y [gd.jstart], sizeof(TF), gd.jtot, pFile) != (unsigned)gd.jtot )
+    if (fread(&gd.y [gd.jstart], sizeof(TF), gd.jtot, pFile) != (unsigned)gd.jtot )
         ++nerror;
-    if(fread(&gd.yh[gd.jstart], sizeof(TF), gd.jtot, pFile) != (unsigned)gd.jtot )
+    if (fread(&gd.yh[gd.jstart], sizeof(TF), gd.jtot, pFile) != (unsigned)gd.jtot )
         ++nerror;
-    if(fread(&gd.z [gd.kstart], sizeof(TF), gd.ktot, pFile) != (unsigned)gd.ktot )
+    if (fread(&gd.z [gd.kstart], sizeof(TF), gd.ktot, pFile) != (unsigned)gd.ktot )
         ++nerror;
-    if(fread(&gd.zh[gd.kstart], sizeof(TF), gd.ktot, pFile) != (unsigned)gd.ktot )
+    if (fread(&gd.zh[gd.kstart], sizeof(TF), gd.ktot, pFile) != (unsigned)gd.ktot )
         ++nerror;
     fclose(pFile);
 

--- a/src/grid_serial.cxx
+++ b/src/grid_serial.cxx
@@ -86,25 +86,31 @@ void Grid<TF>::load_grid()
 
     int nerror = 0;
     if (pFile == NULL)
-    {
-        master.print_message("FAILED\n");
         nerror++;
-    }
-    else
-        master.print_message("OK\n");
+
+    if(fread(&gd.x [gd.istart], sizeof(TF), gd.itot, pFile) != (unsigned)gd.itot )
+        ++nerror;
+    if(fread(&gd.xh[gd.istart], sizeof(TF), gd.itot, pFile) != (unsigned)gd.itot )
+        ++nerror;
+    if(fread(&gd.y [gd.jstart], sizeof(TF), gd.jtot, pFile) != (unsigned)gd.jtot )
+        ++nerror;
+    if(fread(&gd.yh[gd.jstart], sizeof(TF), gd.jtot, pFile) != (unsigned)gd.jtot )
+        ++nerror;
+    if(fread(&gd.z [gd.kstart], sizeof(TF), gd.ktot, pFile) != (unsigned)gd.ktot )
+        ++nerror;
+    if(fread(&gd.zh[gd.kstart], sizeof(TF), gd.ktot, pFile) != (unsigned)gd.ktot )
+        ++nerror;
+    fclose(pFile);
 
     master.sum(&nerror, 1);
 
     if (nerror)
+    {
+        master.print_message("FAILED\n");
         throw std::runtime_error("Error in grid");
-
-    (void)!fread(&gd.x [gd.istart], sizeof(TF), gd.itot, pFile);
-    (void)!fread(&gd.xh[gd.istart], sizeof(TF), gd.itot, pFile);
-    (void)!fread(&gd.y [gd.jstart], sizeof(TF), gd.jtot, pFile);
-    (void)!fread(&gd.yh[gd.jstart], sizeof(TF), gd.jtot, pFile);
-    (void)!fread(&gd.z [gd.kstart], sizeof(TF), gd.ktot, pFile);
-    (void)!fread(&gd.zh[gd.kstart], sizeof(TF), gd.ktot, pFile);
-    fclose(pFile);
+    }
+    else
+        master.print_message("OK\n");
 
     // calculate the missing coordinates
     calculate();

--- a/src/thermo_moist.cxx
+++ b/src/thermo_moist.cxx
@@ -1229,9 +1229,10 @@ void Thermo_moist<TF>::load(const int iotime)
         else
         {
             master.print_message("OK\n");
-
-            (void)!fread(&bs.thvref [gd.kstart], sizeof(TF), gd.ktot  , pFile);
-            (void)!fread(&bs.thvrefh[gd.kstart], sizeof(TF), gd.ktot+1, pFile);
+            if(fread(&bs.thvref [gd.kstart], sizeof(TF), gd.ktot  , pFile) != (unsigned)gd.ktot )
+                ++nerror;
+            if(fread(&bs.thvrefh[gd.kstart], sizeof(TF), gd.ktot+1, pFile) != (unsigned)gd.ktot + 1)
+                ++nerror;
             fclose(pFile);
         }
     }

--- a/src/thermo_moist.cxx
+++ b/src/thermo_moist.cxx
@@ -1230,8 +1230,8 @@ void Thermo_moist<TF>::load(const int iotime)
         {
             master.print_message("OK\n");
 
-            fread(&bs.thvref [gd.kstart], sizeof(TF), gd.ktot  , pFile);
-            fread(&bs.thvrefh[gd.kstart], sizeof(TF), gd.ktot+1, pFile);
+            (void)!fread(&bs.thvref [gd.kstart], sizeof(TF), gd.ktot  , pFile);
+            (void)!fread(&bs.thvrefh[gd.kstart], sizeof(TF), gd.ktot+1, pFile);
             fclose(pFile);
         }
     }

--- a/src/thermo_moist.cxx
+++ b/src/thermo_moist.cxx
@@ -1229,9 +1229,9 @@ void Thermo_moist<TF>::load(const int iotime)
         else
         {
             master.print_message("OK\n");
-            if(fread(&bs.thvref [gd.kstart], sizeof(TF), gd.ktot  , pFile) != (unsigned)gd.ktot )
+            if (fread(&bs.thvref [gd.kstart], sizeof(TF), gd.ktot  , pFile) != (unsigned)gd.ktot )
                 ++nerror;
-            if(fread(&bs.thvrefh[gd.kstart], sizeof(TF), gd.ktot+1, pFile) != (unsigned)gd.ktot + 1)
+            if (fread(&bs.thvrefh[gd.kstart], sizeof(TF), gd.ktot+1, pFile) != (unsigned)gd.ktot + 1)
                 ++nerror;
             fclose(pFile);
         }

--- a/src/timeloop.cxx
+++ b/src/timeloop.cxx
@@ -501,11 +501,11 @@ void Timeloop<TF>::load(int starttime)
         }
         else
         {
-            if(fread(&itime    , sizeof(unsigned long), 1, pFile) != 1 )
+            if (fread(&itime    , sizeof(unsigned long), 1, pFile) != 1 )
                 ++nerror;
-            if(fread(&idt      , sizeof(unsigned long), 1, pFile) != 1 )
+            if (fread(&idt      , sizeof(unsigned long), 1, pFile) != 1 )
                 ++nerror;
-            if(fread(&iteration, sizeof(int), 1, pFile) != 1 )
+            if (fread(&iteration, sizeof(int), 1, pFile) != 1 )
                 ++nerror;
 
             fclose(pFile);

--- a/src/timeloop.cxx
+++ b/src/timeloop.cxx
@@ -501,9 +501,9 @@ void Timeloop<TF>::load(int starttime)
         }
         else
         {
-            fread(&itime    , sizeof(unsigned long), 1, pFile);
-            fread(&idt      , sizeof(unsigned long), 1, pFile);
-            fread(&iteration, sizeof(int), 1, pFile);
+            (void)!fread(&itime    , sizeof(unsigned long), 1, pFile);
+            (void)!fread(&idt      , sizeof(unsigned long), 1, pFile);
+            (void)!fread(&iteration, sizeof(int), 1, pFile);
 
             fclose(pFile);
         }

--- a/src/timeloop.cxx
+++ b/src/timeloop.cxx
@@ -501,9 +501,12 @@ void Timeloop<TF>::load(int starttime)
         }
         else
         {
-            (void)!fread(&itime    , sizeof(unsigned long), 1, pFile);
-            (void)!fread(&idt      , sizeof(unsigned long), 1, pFile);
-            (void)!fread(&iteration, sizeof(int), 1, pFile);
+            if(fread(&itime    , sizeof(unsigned long), 1, pFile) != 1 )
+                ++nerror;
+            if(fread(&idt      , sizeof(unsigned long), 1, pFile) != 1 )
+                ++nerror;
+            if(fread(&iteration, sizeof(int), 1, pFile) != 1 )
+                ++nerror;
 
             fclose(pFile);
         }


### PR DESCRIPTION
The main part of the code now seems to be warning free again.