### PR TITLE
Making multiple stat vars declarations an error.

### DIFF
--- a/src/stats.cxx
+++ b/src/stats.cxx
@@ -1066,7 +1066,7 @@ void Stats<TF>::add_prof(
         return;
 
     if (std::find(varlist.begin(), varlist.end(), name) != varlist.end())
-        return;
+        throw std::runtime_error("Variable " + name + "is added twice in add_prof_series()");
 
     Level_type level;
     if ((zloc == "z") || (zloc == "zs") || (zloc == "era_levels"))
@@ -1136,6 +1136,9 @@ void Stats<TF>::add_fixed_prof(
 {
     auto& gd = grid.get_grid_data();
 
+    if (std::find(varlist.begin(), varlist.end(), name) != varlist.end())
+        throw std::runtime_error("Variable " + name + "is added twice in add_fixed_prof()");
+
     for (auto& mask : masks)
     {
         Mask<TF>& m = mask.second;
@@ -1163,6 +1166,8 @@ void Stats<TF>::add_fixed_prof(
 
         m.data_file->sync();
     }
+    varlist.push_back(name);
+
 }
 
 template<typename TF>
@@ -1174,6 +1179,10 @@ void Stats<TF>::add_fixed_prof_raw(
         const std::string& group_name,
         const std::vector<TF>& prof)
 {
+    
+    if (std::find(varlist.begin(), varlist.end(), name) != varlist.end())
+        throw std::runtime_error("Variable " + name + "is added twice in add_prof_raw()");
+
     for (auto& mask : masks)
     {
         Mask<TF>& m = mask.second;
@@ -1192,6 +1201,8 @@ void Stats<TF>::add_fixed_prof_raw(
 
         m.data_file->sync();
     }
+    varlist.push_back(name);
+
 }
 
 template<typename TF>
@@ -1204,7 +1215,7 @@ void Stats<TF>::add_time_series(
         return;
 
     if (std::find(varlist.begin(), varlist.end(), name) != varlist.end())
-        return;
+        throw std::runtime_error("Variable " + name + "is added twice in add_time_series()");
 
     // Add the series to all files.
     for (auto& mask : masks)

--- a/src/stats.cxx
+++ b/src/stats.cxx
@@ -1066,7 +1066,7 @@ void Stats<TF>::add_prof(
         return;
 
     if (std::find(varlist.begin(), varlist.end(), name) != varlist.end())
-        throw std::runtime_error("Variable " + name + "is added twice in add_prof_series()");
+        throw std::runtime_error("Variable " + name + " is added twice in add_prof_series()");
 
     Level_type level;
     if ((zloc == "z") || (zloc == "zs") || (zloc == "era_levels"))
@@ -1137,7 +1137,7 @@ void Stats<TF>::add_fixed_prof(
     auto& gd = grid.get_grid_data();
 
     if (std::find(varlist.begin(), varlist.end(), name) != varlist.end())
-        throw std::runtime_error("Variable " + name + "is added twice in add_fixed_prof()");
+        throw std::runtime_error("Variable " + name + " is added twice in add_fixed_prof()");
 
     for (auto& mask : masks)
     {
@@ -1181,7 +1181,7 @@ void Stats<TF>::add_fixed_prof_raw(
 {
     
     if (std::find(varlist.begin(), varlist.end(), name) != varlist.end())
-        throw std::runtime_error("Variable " + name + "is added twice in add_prof_raw()");
+        throw std::runtime_error("Variable " + name + " is added twice in add_prof_raw()");
 
     for (auto& mask : masks)
     {
@@ -1215,7 +1215,7 @@ void Stats<TF>::add_time_series(
         return;
 
     if (std::find(varlist.begin(), varlist.end(), name) != varlist.end())
-        throw std::runtime_error("Variable " + name + "is added twice in add_time_series()");
+        throw std::runtime_error("Variable " + name + " is added twice in add_time_series()");
 
     // Add the series to all files.
     for (auto& mask : masks)

--- a/src/thermo_moist.cxx
+++ b/src/thermo_moist.cxx
@@ -1920,10 +1920,6 @@ void Thermo_moist<TF>::create_stats(Stats<TF>& stats)
         fields.release_tmp(rh);
 
         stats.add_time_series("zi", "Boundary Layer Depth", "m", group_name);
-
-        stats.add_time_series("thl_bot", "Surface liquid water potential temperature", "K", group_name);
-        stats.add_time_series("qt_bot", "Surface specific humidity", "kg kg-1", group_name);
-
         stats.add_tendency(*fields.mt.at("w"), "zh", tend_name, tend_longname, group_name);
     }
 }


### PR DESCRIPTION
While testing for BOMEX, two hard coded  thl/qt_bot in thermo moist fell out. There may be more; we'll find them in the testing all cases. 