### PR TITLE
Add `#ifdef FLOAT_SINGLE` to all source files

### DIFF
--- a/src/advec.cxx
+++ b/src/advec.cxx
@@ -95,6 +95,7 @@ std::shared_ptr<Advec<TF>> Advec<TF>::factory(
     }
 }
 
+
 #ifdef FLOAT_SINGLE
 template class Advec<float>;
 #else

--- a/src/advec.cxx
+++ b/src/advec.cxx
@@ -95,5 +95,8 @@ std::shared_ptr<Advec<TF>> Advec<TF>::factory(
     }
 }
 
-template class Advec<double>;
+#ifdef FLOAT_SINGLE
 template class Advec<float>;
+#else
+template class Advec<double>;
+#endif

--- a/src/advec_2.cu
+++ b/src/advec_2.cu
@@ -225,5 +225,9 @@ void Advec_2<TF>::exec(Stats<TF>& stats)
 }
 #endif
 
-template class Advec_2<double>;
+
+#ifdef FLOAT_SINGLE
 template class Advec_2<float>;
+#else
+template class Advec_2<double>;
+#endif

--- a/src/advec_2.cxx
+++ b/src/advec_2.cxx
@@ -366,6 +366,7 @@ void Advec_2<TF>::get_advec_flux(
         throw std::runtime_error("Advec_2 cannot deliver flux field at that location");
 }
 
+
 #ifdef FLOAT_SINGLE
 template class Advec_2<float>;
 #else

--- a/src/advec_2.cxx
+++ b/src/advec_2.cxx
@@ -366,5 +366,8 @@ void Advec_2<TF>::get_advec_flux(
         throw std::runtime_error("Advec_2 cannot deliver flux field at that location");
 }
 
-template class Advec_2<double>;
+#ifdef FLOAT_SINGLE
 template class Advec_2<float>;
+#else
+template class Advec_2<double>;
+#endif

--- a/src/advec_2i4.cu
+++ b/src/advec_2i4.cu
@@ -490,5 +490,9 @@ void Advec_2i4<TF>::exec(Stats<TF>& stats)
 }
 #endif
 
-template class Advec_2i4<double>;
+
+#ifdef FLOAT_SINGLE
 template class Advec_2i4<float>;
+#else
+template class Advec_2i4<double>;
+#endif

--- a/src/advec_2i4.cxx
+++ b/src/advec_2i4.cxx
@@ -751,6 +751,7 @@ void Advec_2i4<TF>::get_advec_flux(
         throw std::runtime_error("Advec_2 cannot deliver flux field at that location");
 }
 
+
 #ifdef FLOAT_SINGLE
 template class Advec_2i4<float>;
 #else

--- a/src/advec_2i4.cxx
+++ b/src/advec_2i4.cxx
@@ -751,5 +751,8 @@ void Advec_2i4<TF>::get_advec_flux(
         throw std::runtime_error("Advec_2 cannot deliver flux field at that location");
 }
 
-template class Advec_2i4<double>;
+#ifdef FLOAT_SINGLE
 template class Advec_2i4<float>;
+#else
+template class Advec_2i4<double>;
+#endif

--- a/src/advec_2i5.cu
+++ b/src/advec_2i5.cu
@@ -735,5 +735,8 @@ void Advec_2i5<TF>::exec(Stats<TF>& stats)
 #endif
 
 
-template class Advec_2i5<double>;
+#ifdef FLOAT_SINGLE
 template class Advec_2i5<float>;
+#else
+template class Advec_2i5<double>;
+#endif

--- a/src/advec_2i5.cxx
+++ b/src/advec_2i5.cxx
@@ -1081,5 +1081,8 @@ void Advec_2i5<TF>::get_advec_flux(
         throw std::runtime_error("Advec_2i5 cannot deliver flux field at that location");
 }
 
-template class Advec_2i5<double>;
+#ifdef FLOAT_SINGLE
 template class Advec_2i5<float>;
+#else
+template class Advec_2i5<double>;
+#endif

--- a/src/advec_2i5.cxx
+++ b/src/advec_2i5.cxx
@@ -1081,6 +1081,7 @@ void Advec_2i5<TF>::get_advec_flux(
         throw std::runtime_error("Advec_2i5 cannot deliver flux field at that location");
 }
 
+
 #ifdef FLOAT_SINGLE
 template class Advec_2i5<float>;
 #else

--- a/src/advec_2i62.cu
+++ b/src/advec_2i62.cu
@@ -473,5 +473,8 @@ void Advec_2i62<TF>::exec(Stats<TF>& stats)
 #endif
 
 
-template class Advec_2i62<double>;
+#ifdef FLOAT_SINGLE
 template class Advec_2i62<float>;
+#else
+template class Advec_2i62<double>;
+#endif

--- a/src/advec_2i62.cxx
+++ b/src/advec_2i62.cxx
@@ -525,5 +525,8 @@ void Advec_2i62<TF>::get_advec_flux(
         throw std::runtime_error("Advec_2i62 cannot deliver flux field at that location");
 }
 
-template class Advec_2i62<double>;
+#ifdef FLOAT_SINGLE
 template class Advec_2i62<float>;
+#else
+template class Advec_2i62<double>;
+#endif

--- a/src/advec_4.cu
+++ b/src/advec_4.cu
@@ -627,5 +627,9 @@ void Advec_4<TF>::exec(Stats<TF>& stats)
 }
 #endif
 
-template class Advec_4<double>;
+
+#ifdef FLOAT_SINGLE
 template class Advec_4<float>;
+#else
+template class Advec_4<double>;
+#endif

--- a/src/advec_4.cxx
+++ b/src/advec_4.cxx
@@ -695,5 +695,8 @@ void Advec_4<TF>::get_advec_flux(
         throw std::runtime_error("Advec_2 cannot deliver flux field at that location");
 }
 
-template class Advec_4<double>;
+#ifdef FLOAT_SINGLE
 template class Advec_4<float>;
+#else
+template class Advec_4<double>;
+#endif

--- a/src/advec_4.cxx
+++ b/src/advec_4.cxx
@@ -695,6 +695,7 @@ void Advec_4<TF>::get_advec_flux(
         throw std::runtime_error("Advec_2 cannot deliver flux field at that location");
 }
 
+
 #ifdef FLOAT_SINGLE
 template class Advec_4<float>;
 #else

--- a/src/advec_4m.cu
+++ b/src/advec_4m.cu
@@ -458,5 +458,9 @@ void Advec_4m<TF>::exec(Stats<TF>& stats)
 }
 #endif
 
-template class Advec_4m<double>;
+
+#ifdef FLOAT_SINGLE
 template class Advec_4m<float>;
+#else
+template class Advec_4m<double>;
+#endif

--- a/src/advec_4m.cxx
+++ b/src/advec_4m.cxx
@@ -626,6 +626,7 @@ void Advec_4m<TF>::get_advec_flux(
         throw std::runtime_error("Advec_2 cannot deliver flux field at that location");
 }
 
+
 #ifdef FLOAT_SINGLE
 template class Advec_4m<float>;
 #else

--- a/src/advec_4m.cxx
+++ b/src/advec_4m.cxx
@@ -626,5 +626,8 @@ void Advec_4m<TF>::get_advec_flux(
         throw std::runtime_error("Advec_2 cannot deliver flux field at that location");
 }
 
-template class Advec_4m<double>;
+#ifdef FLOAT_SINGLE
 template class Advec_4m<float>;
+#else
+template class Advec_4m<double>;
+#endif

--- a/src/advec_disabled.cxx
+++ b/src/advec_disabled.cxx
@@ -65,5 +65,8 @@ void Advec_disabled<TF>::get_advec_flux(
     std::fill(advec_flux.fld.begin(), advec_flux.fld.end(), TF(0.));
 }
 
-template class Advec_disabled<double>;
+#ifdef FLOAT_SINGLE
 template class Advec_disabled<float>;
+#else
+template class Advec_disabled<double>;
+#endif

--- a/src/advec_disabled.cxx
+++ b/src/advec_disabled.cxx
@@ -65,6 +65,7 @@ void Advec_disabled<TF>::get_advec_flux(
     std::fill(advec_flux.fld.begin(), advec_flux.fld.end(), TF(0.));
 }
 
+
 #ifdef FLOAT_SINGLE
 template class Advec_disabled<float>;
 #else

--- a/src/aerosol.cu
+++ b/src/aerosol.cu
@@ -127,8 +127,8 @@ void Aerosol<TF>::get_radiation_fields(std::unique_ptr<Aerosol_concs_gpu>& aeros
     aerosol_concs_gpu->set_vmr("aermr11", aermr11_a.subset({ {{1, ncol}, {kstart, kend}}} ));
 
 }
-
 #endif
+
 
 #ifdef FLOAT_SINGLE
 template class Aerosol<float>;

--- a/src/aerosol.cxx
+++ b/src/aerosol.cxx
@@ -214,6 +214,7 @@ void Aerosol<TF>::get_radiation_fields(Aerosol_concs& aerosol_concs)
 }
 #endif
 
+
 #ifdef FLOAT_SINGLE
 template class Aerosol<float>;
 #else

--- a/src/background_profs.cxx
+++ b/src/background_profs.cxx
@@ -344,6 +344,7 @@ void Background<TF>::get_aerosols(Aerosol_concs& aerosol_concs_col)
     aerosol_concs_col.set_vmr("aermr11", aermr11_bg_a);
 }
 
+
 #ifdef FLOAT_SINGLE
 template class Background<float>;
 #else

--- a/src/background_profs.cxx
+++ b/src/background_profs.cxx
@@ -344,5 +344,8 @@ void Background<TF>::get_aerosols(Aerosol_concs& aerosol_concs_col)
     aerosol_concs_col.set_vmr("aermr11", aermr11_bg_a);
 }
 
-template class Background<double>;
+#ifdef FLOAT_SINGLE
 template class Background<float>;
+#else
+template class Background<double>;
+#endif

--- a/src/boundary.cu
+++ b/src/boundary.cu
@@ -764,6 +764,7 @@ void Boundary<TF>::backward_device()
 }
 #endif
 
+
 #ifdef FLOAT_SINGLE
 template class Boundary<float>;
 #else

--- a/src/boundary.cu
+++ b/src/boundary.cu
@@ -764,5 +764,8 @@ void Boundary<TF>::backward_device()
 }
 #endif
 
-template class Boundary<double>;
+#ifdef FLOAT_SINGLE
 template class Boundary<float>;
+#else
+template class Boundary<double>;
+#endif

--- a/src/boundary.cxx
+++ b/src/boundary.cxx
@@ -1161,5 +1161,8 @@ std::shared_ptr<Boundary<TF>> Boundary<TF>::factory(
     }
 }
 
-template class Boundary<double>;
+#ifdef FLOAT_SINGLE
 template class Boundary<float>;
+#else
+template class Boundary<double>;
+#endif

--- a/src/boundary.cxx
+++ b/src/boundary.cxx
@@ -1161,6 +1161,7 @@ std::shared_ptr<Boundary<TF>> Boundary<TF>::factory(
     }
 }
 
+
 #ifdef FLOAT_SINGLE
 template class Boundary<float>;
 #else

--- a/src/boundary_cyclic.cu
+++ b/src/boundary_cyclic.cu
@@ -159,5 +159,8 @@ void Boundary_cyclic<TF>::exec_2d_g(TF* data)
     cuda_check_error();
 }
 
-template class Boundary_cyclic<double>;
+#ifdef FLOAT_SINGLE
 template class Boundary_cyclic<float>;
+#else
+template class Boundary_cyclic<double>;
+#endif

--- a/src/boundary_cyclic.cu
+++ b/src/boundary_cyclic.cu
@@ -159,6 +159,7 @@ void Boundary_cyclic<TF>::exec_2d_g(TF* data)
     cuda_check_error();
 }
 
+
 #ifdef FLOAT_SINGLE
 template class Boundary_cyclic<float>;
 #else

--- a/src/boundary_cyclic.cxx
+++ b/src/boundary_cyclic.cxx
@@ -647,6 +647,7 @@ void Boundary_cyclic<TF>::exec_2d(unsigned int* restrict data)
 }
 #endif
 
+
 #ifdef FLOAT_SINGLE
 template class Boundary_cyclic<float>;
 #else

--- a/src/boundary_cyclic.cxx
+++ b/src/boundary_cyclic.cxx
@@ -647,5 +647,8 @@ void Boundary_cyclic<TF>::exec_2d(unsigned int* restrict data)
 }
 #endif
 
-template class Boundary_cyclic<double>;
+#ifdef FLOAT_SINGLE
 template class Boundary_cyclic<float>;
+#else
+template class Boundary_cyclic<double>;
+#endif

--- a/src/boundary_outflow.cu
+++ b/src/boundary_outflow.cu
@@ -291,6 +291,7 @@ void Boundary_outflow<TF>::exec(
 }
 #endif
 
+
 #ifdef FLOAT_SINGLE
 template class Boundary_outflow<float>;
 #else

--- a/src/boundary_outflow.cu
+++ b/src/boundary_outflow.cu
@@ -291,5 +291,8 @@ void Boundary_outflow<TF>::exec(
 }
 #endif
 
-template class Boundary_outflow<double>;
+#ifdef FLOAT_SINGLE
 template class Boundary_outflow<float>;
+#else
+template class Boundary_outflow<double>;
+#endif

--- a/src/boundary_outflow.cxx
+++ b/src/boundary_outflow.cxx
@@ -343,5 +343,8 @@ void Boundary_outflow<TF>::exec(
 }
 #endif
 
-template class Boundary_outflow<double>;
+#ifdef FLOAT_SINGLE
 template class Boundary_outflow<float>;
+#else
+template class Boundary_outflow<double>;
+#endif

--- a/src/boundary_outflow.cxx
+++ b/src/boundary_outflow.cxx
@@ -343,6 +343,7 @@ void Boundary_outflow<TF>::exec(
 }
 #endif
 
+
 #ifdef FLOAT_SINGLE
 template class Boundary_outflow<float>;
 #else

--- a/src/boundary_surface.cu
+++ b/src/boundary_surface.cu
@@ -534,6 +534,7 @@ void Boundary_surface<TF>::exec_column(Column<TF>& column)
 }
 #endif
 
+
 #ifdef FLOAT_SINGLE
 template class Boundary_surface<float>;
 #else

--- a/src/boundary_surface.cu
+++ b/src/boundary_surface.cu
@@ -534,5 +534,8 @@ void Boundary_surface<TF>::exec_column(Column<TF>& column)
 }
 #endif
 
-template class Boundary_surface<double>;
+#ifdef FLOAT_SINGLE
 template class Boundary_surface<float>;
+#else
+template class Boundary_surface<double>;
+#endif

--- a/src/boundary_surface.cxx
+++ b/src/boundary_surface.cxx
@@ -990,5 +990,8 @@ void Boundary_surface<TF>::update_slave_bcs()
     // the fields are computed by the surface model in update_bcs.
 }
 
-template class Boundary_surface<double>;
+#ifdef FLOAT SINGLE
 template class Boundary_surface<float>;
+#else
+template class Boundary_surface<double>;
+#endif

--- a/src/boundary_surface.cxx
+++ b/src/boundary_surface.cxx
@@ -990,7 +990,8 @@ void Boundary_surface<TF>::update_slave_bcs()
     // the fields are computed by the surface model in update_bcs.
 }
 
-#ifdef FLOAT SINGLE
+
+#ifdef FLOAT_SINGLE
 template class Boundary_surface<float>;
 #else
 template class Boundary_surface<double>;

--- a/src/boundary_surface_bulk.cu
+++ b/src/boundary_surface_bulk.cu
@@ -329,6 +329,7 @@ void Boundary_surface_bulk<TF>::exec(
 }
 #endif
 
+
 #ifdef FLOAT_SINGLE
 template class Boundary_surface_bulk<float>;
 #else

--- a/src/boundary_surface_bulk.cu
+++ b/src/boundary_surface_bulk.cu
@@ -329,5 +329,8 @@ void Boundary_surface_bulk<TF>::exec(
 }
 #endif
 
-template class Boundary_surface_bulk<double>;
+#ifdef FLOAT_SINGLE
 template class Boundary_surface_bulk<float>;
+#else
+template class Boundary_surface_bulk<double>;
+#endif

--- a/src/boundary_surface_bulk.cxx
+++ b/src/boundary_surface_bulk.cxx
@@ -409,6 +409,7 @@ void Boundary_surface_bulk<TF>::update_slave_bcs()
     // the fields are computed by the surface model in update_bcs.
 }
 
+
 #ifdef FLOAT_SINGLE
 template class Boundary_surface_bulk<float>;
 #else

--- a/src/boundary_surface_bulk.cxx
+++ b/src/boundary_surface_bulk.cxx
@@ -409,5 +409,8 @@ void Boundary_surface_bulk<TF>::update_slave_bcs()
     // the fields are computed by the surface model in update_bcs.
 }
 
-template class Boundary_surface_bulk<double>;
+#ifdef FLOAT_SINGLE
 template class Boundary_surface_bulk<float>;
+#else
+template class Boundary_surface_bulk<double>;
+#endif

--- a/src/boundary_surface_lsm.cu
+++ b/src/boundary_surface_lsm.cu
@@ -1116,5 +1116,9 @@ void Boundary_surface_lsm<TF>::clear_device()
 }
 #endif
 
-template class Boundary_surface_lsm<double>;
+
+#ifdef FLOAT_SINGLE
 template class Boundary_surface_lsm<float>;
+#else
+template class Boundary_surface_lsm<double>;
+#endif

--- a/src/boundary_surface_lsm.cxx
+++ b/src/boundary_surface_lsm.cxx
@@ -1800,5 +1800,8 @@ void Boundary_surface_lsm<TF>::get_tiled_mean(
 }
 
 
-template class Boundary_surface_lsm<double>;
+#ifdef FLOAT_SINGLE
 template class Boundary_surface_lsm<float>;
+#else
+template class Boundary_surface_lsm<double>;
+#endif

--- a/src/budget.cxx
+++ b/src/budget.cxx
@@ -69,5 +69,9 @@ std::shared_ptr<Budget<TF>> Budget<TF>::factory(
     }
 }
 
-template class Budget<double>;
+
+#ifdef FLOAT_SINGLE
 template class Budget<float>;
+#else
+template class Budget<double>;
+#endif

--- a/src/budget_2.cxx
+++ b/src/budget_2.cxx
@@ -1817,5 +1817,9 @@ void Budget_2<TF>::exec_stats(Stats<TF>& stats)
     }
 }
 
-template class Budget_2<double>;
+
+#ifdef FLOAT_SINGLE
 template class Budget_2<float>;
+#else
+template class Budget_2<double>;
+#endif

--- a/src/budget_4.cxx
+++ b/src/budget_4.cxx
@@ -3100,5 +3100,9 @@ void Budget_4<TF>::exec_stats(Stats<TF>& stats)
     }
 }
 
-template class Budget_4<double>;
+
+#ifdef FLOAT_SINGLE
 template class Budget_4<float>;
+#else
+template class Budget_4<double>;
+#endif

--- a/src/budget_disabled.cxx
+++ b/src/budget_disabled.cxx
@@ -45,5 +45,9 @@ template<typename TF>
 void Budget_disabled<TF>::exec_stats(Stats<TF>&)
 {}
 
-template class Budget_disabled<double>;
+
+#ifdef FLOAT_SINGLE
 template class Budget_disabled<float>;
+#else
+template class Budget_disabled<double>;
+#endif

--- a/src/buffer.cu
+++ b/src/buffer.cu
@@ -202,5 +202,9 @@ void Buffer<TF>::exec(Stats<TF>& stats)
 }
 #endif
 
-template class Buffer<double>;
+
+#ifdef FLOAT_SINGLE
 template class Buffer<float>;
+#else
+template class Buffer<double>;
+#endif

--- a/src/buffer.cxx
+++ b/src/buffer.cxx
@@ -206,5 +206,9 @@ void Buffer<TF>::exec(Stats<TF>& stats)
 }
 #endif
 
-template class Buffer<double>;
+
+#ifdef FLOAT_SINGLE
 template class Buffer<float>;
+#else
+template class Buffer<double>;
+#endif

--- a/src/column.cu
+++ b/src/column.cu
@@ -135,5 +135,9 @@ void Column<TF>::clear_device()
 }
 #endif
 
-template class Column<double>;
+
+#ifdef FLOAT_SINGLE
 template class Column<float>;
+#else
+template class Column<double>;
+#endif

--- a/src/column.cxx
+++ b/src/column.cxx
@@ -374,5 +374,9 @@ void Column<TF>::calc_time_series(
 }
 #endif
 
-template class Column<double>;
+
+#ifdef FLOAT_SINGLE
 template class Column<float>;
+#else
+template class Column<double>;
+#endif

--- a/src/cross.cxx
+++ b/src/cross.cxx
@@ -799,5 +799,8 @@ int Cross<TF>::cross_soil(
 }
 
 
-template class Cross<double>;
+#ifdef FLOAT_SINGLE
 template class Cross<float>;
+#else
+template class Cross<double>;
+#endif

--- a/src/decay.cu
+++ b/src/decay.cu
@@ -81,5 +81,9 @@ void Decay<TF>::exec(double dt, Stats<TF>& stats)
 }
 #endif
 
-template class Decay<double>;
+
+#ifdef FLOAT_SINGLE
 template class Decay<float>;
+#else
+template class Decay<double>;
+#endif

--- a/src/decay.cxx
+++ b/src/decay.cxx
@@ -186,5 +186,9 @@ void Decay<TF>::get_mask(Stats<TF>& stats, std::string mask_name)
     }
 }
 
-template class Decay<double>;
+
+#ifdef FLOAT_SINGLE
 template class Decay<float>;
+#else
+template class Decay<double>;
+#endif

--- a/src/diff.cxx
+++ b/src/diff.cxx
@@ -91,5 +91,9 @@ std::shared_ptr<Diff<TF>> Diff<TF>::factory(
     }
 }
 
-template class Diff<double>;
+
+#ifdef FLOAT_SINGLE
 template class Diff<float>;
+#else
+template class Diff<double>;
+#endif

--- a/src/diff_2.cu
+++ b/src/diff_2.cu
@@ -148,5 +148,9 @@ void Diff_2<TF>::exec(Stats<TF>& stats)
 }
 #endif
 
-template class Diff_2<double>;
+
+#ifdef FLOAT_SINGLE
 template class Diff_2<float>;
+#else
+template class Diff_2<double>;
+#endif

--- a/src/diff_2.cxx
+++ b/src/diff_2.cxx
@@ -195,5 +195,9 @@ void Diff_2<TF>::diff_flux(Field3d<TF>& restrict out, const Field3d<TF>& restric
     calc_diff_flux(out.fld.data(), data.fld.data(), data.visc, gd.dzhi.data(), gd.istart, gd.iend, gd.jstart, gd.jend, gd.kstart, gd.kend, gd.icells, gd.ijcells);
 }
 
-template class Diff_2<double>;
+
+#ifdef FLOAT_SINGLE
 template class Diff_2<float>;
+#else
+template class Diff_2<double>;
+#endif

--- a/src/diff_4.cu
+++ b/src/diff_4.cu
@@ -218,5 +218,9 @@ void Diff_4<TF>::exec(Stats<TF>& stats)
 }
 #endif
 
-template class Diff_4<double>;
+
+#ifdef FLOAT_SINGLE
 template class Diff_4<float>;
+#else
+template class Diff_4<double>;
+#endif

--- a/src/diff_4.cxx
+++ b/src/diff_4.cxx
@@ -313,5 +313,9 @@ void Diff_4<TF>::diff_flux(Field3d<TF>& restrict out, const Field3d<TF>& in)
             gd.icells, gd.ijcells);
 }
 
-template class Diff_4<double>;
+
+#ifdef FLOAT_SINGLE
 template class Diff_4<float>;
+#else
+template class Diff_4<double>;
+#endif

--- a/src/diff_disabled.cxx
+++ b/src/diff_disabled.cxx
@@ -63,5 +63,10 @@ void Diff_disabled<TF>::diff_flux(Field3d<TF>& restrict out, const Field3d<TF>& 
 {
     std::fill(out.fld.begin(), out.fld.end(), TF(0.));
 }
-template class Diff_disabled<double>;
+
+
+#ifdef FLOAT_SINGLE
 template class Diff_disabled<float>;
+#else
+template class Diff_disabled<double>;
+#endif

--- a/src/diff_smag2.cu
+++ b/src/diff_smag2.cu
@@ -869,5 +869,9 @@ double Diff_smag2<TF>::get_dn(double dt)
 }
 #endif
 
-template class Diff_smag2<double>;
+
+#ifdef FLOAT_SINGLE
 template class Diff_smag2<float>;
+#else
+template class Diff_smag2<double>;
+#endif

--- a/src/diff_smag2.cxx
+++ b/src/diff_smag2.cxx
@@ -1275,5 +1275,9 @@ void Diff_smag2<TF>::diff_flux(Field3d<TF>& restrict out, const Field3d<TF>& res
     }
 }
 
-template class Diff_smag2<double>;
+
+#ifdef FLOAT_SINGLE
 template class Diff_smag2<float>;
+#else
+template class Diff_smag2<double>;
+#endif

--- a/src/dump.cxx
+++ b/src/dump.cxx
@@ -146,5 +146,9 @@ void Dump<TF>::save_dump(TF* data, const std::string& varname, int iotime)
     }
 }
 
-template class Dump<double>;
+
+#ifdef FLOAT_SINGLE
 template class Dump<float>;
+#else
+template class Dump<double>;
+#endif

--- a/src/fft.cxx
+++ b/src/fft.cxx
@@ -598,5 +598,9 @@ void FFT<TF>::exec_backward(TF* const restrict data, TF* const restrict tmp1)
             iplanb, iplanbf, jplanb, jplanbf, grid.get_grid_data(), transpose);
 }
 
-template class FFT<double>;
+
+#ifdef FLOAT_SINGLE
 template class FFT<float>;
+#else
+template class FFT<double>;
+#endif

--- a/src/fft.cxx
+++ b/src/fft.cxx
@@ -26,6 +26,7 @@
 #include "grid.h"
 #include "fft.h"
 
+
 template<typename TF>
 FFT<TF>::FFT(Master& masterin, Grid<TF>& gridin) :
     master(masterin), grid(gridin),
@@ -40,6 +41,21 @@ FFT<TF>::FFT(Master& masterin, Grid<TF>& gridin) :
     fftoutj = nullptr;
 }
 
+
+#ifdef FLOAT_SINGLE
+template<>
+void FFT<float>::init()
+{
+    auto& gd = grid.get_grid_data();
+
+    fftini  = fftwf_alloc_real(gd.itot*gd.jmax);
+    fftouti = fftwf_alloc_real(gd.itot*gd.jmax);
+    fftinj  = fftwf_alloc_real(gd.jtot*gd.iblock);
+    fftoutj = fftwf_alloc_real(gd.jtot*gd.iblock);
+
+    transpose.init();
+}
+#else
 template<>
 void FFT<double>::init()
 {
@@ -52,22 +68,29 @@ void FFT<double>::init()
 
     transpose.init();
 }
+#endif
 
+
+#ifdef FLOAT_SINGLE
 template<>
-void FFT<float>::init()
+FFT<float>::~FFT()
 {
-    auto& gd = grid.get_grid_data();
+    if (has_fftw_plan)
+    {
+        fftwf_destroy_plan(iplanff);
+        fftwf_destroy_plan(iplanbf);
+        fftwf_destroy_plan(jplanff);
+        fftwf_destroy_plan(jplanbf);
+    }
 
-    #ifdef FLOAT_SINGLE
-    fftini  = fftwf_alloc_real(gd.itot*gd.jmax);
-    fftouti = fftwf_alloc_real(gd.itot*gd.jmax);
-    fftinj  = fftwf_alloc_real(gd.jtot*gd.iblock);
-    fftoutj = fftwf_alloc_real(gd.jtot*gd.iblock);
-    #endif
+    fftwf_free(fftini);
+    fftwf_free(fftouti);
+    fftwf_free(fftinj);
+    fftwf_free(fftoutj);
 
-    transpose.init();
+    fftwf_cleanup();
 }
-
+#else
 template<>
 FFT<double>::~FFT()
 {
@@ -86,28 +109,56 @@ FFT<double>::~FFT()
 
     fftw_cleanup();
 }
+#endif
 
+
+#ifdef FLOAT_SINGLE
 template<>
-FFT<float>::~FFT()
+void FFT<float>::load()
 {
-    #ifdef FLOAT_SINGLE
-    if (has_fftw_plan)
+    // LOAD THE FFTW PLAN
+    auto& gd = grid.get_grid_data();
+
+    char filename[256];
+    std::sprintf(filename, "%s.%07d", "fftwplan", 0);
+
+    master.print_message("Loading \"%s\" ... ", filename);
+
+    int n = fftwf_import_wisdom_from_filename(filename);
+    if (n == 0)
     {
-        fftwf_destroy_plan(iplanff);
-        fftwf_destroy_plan(iplanbf);
-        fftwf_destroy_plan(jplanff);
-        fftwf_destroy_plan(jplanbf);
+        master.print_message("FAILED\n");
+        throw std::runtime_error("Error loading FFTW Plan");
     }
+    else
+        master.print_message("OK\n");
 
-    fftwf_free(fftini);
-    fftwf_free(fftouti);
-    fftwf_free(fftinj);
-    fftwf_free(fftoutj);
+    // use the FFTW3 many interface in order to reduce function call overhead
+    int rank = 1;
+    int ni[] = {gd.itot};
+    int nj[] = {gd.jtot};
+    int istride = 1;
+    int jstride = gd.iblock;
+    int idist = gd.itot;
+    int jdist = 1;
 
-    fftwf_cleanup();
-    #endif
+    fftwf_r2r_kind kindf[] = {FFTW_R2HC};
+    fftwf_r2r_kind kindb[] = {FFTW_HC2R};
+
+    iplanff = fftwf_plan_many_r2r(rank, ni, gd.jmax, fftini, ni, istride, idist,
+            fftouti, ni, istride, idist, kindf, FFTW_ESTIMATE);
+    iplanbf = fftwf_plan_many_r2r(rank, ni, gd.jmax, fftini, ni, istride, idist,
+            fftouti, ni, istride, idist, kindb, FFTW_ESTIMATE);
+    jplanff = fftwf_plan_many_r2r(rank, nj, gd.iblock, fftinj, nj, jstride, jdist,
+            fftoutj, nj, jstride, jdist, kindf, FFTW_ESTIMATE);
+    jplanbf = fftwf_plan_many_r2r(rank, nj, gd.iblock, fftinj, nj, jstride, jdist,
+            fftoutj, nj, jstride, jdist, kindb, FFTW_ESTIMATE);
+
+    has_fftw_plan = true;
+
+    fftwf_forget_wisdom();
 }
-
+#else
 template<>
 void FFT<double>::load()
 {
@@ -153,30 +204,17 @@ void FFT<double>::load()
 
     fftw_forget_wisdom();
 }
+#endif
 
 
+#ifdef FLOAT_SINGLE
 template<>
-void FFT<float>::load()
+void FFT<float>::save()
 {
-    #ifdef FLOAT_SINGLE
-    // LOAD THE FFTW PLAN
+    // SAVE THE FFTW PLAN IN ORDER TO ENSURE BITWISE IDENTICAL RESTARTS
+    // Use the FFTW3 many interface in order to reduce function call overhead.
     auto& gd = grid.get_grid_data();
 
-    char filename[256];
-    std::sprintf(filename, "%s.%07d", "fftwplan", 0);
-
-    master.print_message("Loading \"%s\" ... ", filename);
-
-    int n = fftwf_import_wisdom_from_filename(filename);
-    if (n == 0)
-    {
-        master.print_message("FAILED\n");
-        throw std::runtime_error("Error loading FFTW Plan");
-    }
-    else
-        master.print_message("OK\n");
-
-    // use the FFTW3 many interface in order to reduce function call overhead
     int rank = 1;
     int ni[] = {gd.itot};
     int nj[] = {gd.jtot};
@@ -189,21 +227,40 @@ void FFT<float>::load()
     fftwf_r2r_kind kindb[] = {FFTW_HC2R};
 
     iplanff = fftwf_plan_many_r2r(rank, ni, gd.jmax, fftini, ni, istride, idist,
-            fftouti, ni, istride, idist, kindf, FFTW_ESTIMATE);
+                                  fftouti, ni, istride, idist, kindf, FFTW_ESTIMATE);
     iplanbf = fftwf_plan_many_r2r(rank, ni, gd.jmax, fftini, ni, istride, idist,
-            fftouti, ni, istride, idist, kindb, FFTW_ESTIMATE);
+                                  fftouti, ni, istride, idist, kindb, FFTW_ESTIMATE);
     jplanff = fftwf_plan_many_r2r(rank, nj, gd.iblock, fftinj, nj, jstride, jdist,
-            fftoutj, nj, jstride, jdist, kindf, FFTW_ESTIMATE);
+                                  fftoutj, nj, jstride, jdist, kindf, FFTW_ESTIMATE);
     jplanbf = fftwf_plan_many_r2r(rank, nj, gd.iblock, fftinj, nj, jstride, jdist,
-            fftoutj, nj, jstride, jdist, kindb, FFTW_ESTIMATE);
+                                  fftoutj, nj, jstride, jdist, kindb, FFTW_ESTIMATE);
 
     has_fftw_plan = true;
 
-    fftwf_forget_wisdom();
-    #endif
+    int nerror = 0;
+    if (master.get_mpiid() == 0)
+    {
+        char filename[256];
+        std::sprintf(filename, "%s.%07d", "fftwplan", 0);
+
+        master.print_message("Saving \"%s\" ... ", filename);
+
+        int n = fftwf_export_wisdom_to_filename(filename);
+        if (n == 0)
+        {
+            master.print_message("FAILED\n");
+            nerror++;
+        }
+        else
+            master.print_message("OK\n");
+    }
+
+    master.sum(&nerror, 1);
+
+    if (nerror)
+        throw std::runtime_error("Error saving FFTW plan");
 }
-
-
+#else
 template<>
 void FFT<double>::save()
 {
@@ -256,79 +313,26 @@ void FFT<double>::save()
     if (nerror)
         throw std::runtime_error("Error saving FFTW plan");
 }
+#endif
 
-template<>
-void FFT<float>::save()
-{
-    #ifdef FLOAT_SINGLE
-    // SAVE THE FFTW PLAN IN ORDER TO ENSURE BITWISE IDENTICAL RESTARTS
-    // Use the FFTW3 many interface in order to reduce function call overhead.
-    auto& gd = grid.get_grid_data();
-
-    int rank = 1;
-    int ni[] = {gd.itot};
-    int nj[] = {gd.jtot};
-    int istride = 1;
-    int jstride = gd.iblock;
-    int idist = gd.itot;
-    int jdist = 1;
-
-    fftwf_r2r_kind kindf[] = {FFTW_R2HC};
-    fftwf_r2r_kind kindb[] = {FFTW_HC2R};
-
-    iplanff = fftwf_plan_many_r2r(rank, ni, gd.jmax, fftini, ni, istride, idist,
-                                  fftouti, ni, istride, idist, kindf, FFTW_ESTIMATE);
-    iplanbf = fftwf_plan_many_r2r(rank, ni, gd.jmax, fftini, ni, istride, idist,
-                                  fftouti, ni, istride, idist, kindb, FFTW_ESTIMATE);
-    jplanff = fftwf_plan_many_r2r(rank, nj, gd.iblock, fftinj, nj, jstride, jdist,
-                                  fftoutj, nj, jstride, jdist, kindf, FFTW_ESTIMATE);
-    jplanbf = fftwf_plan_many_r2r(rank, nj, gd.iblock, fftinj, nj, jstride, jdist,
-                                  fftoutj, nj, jstride, jdist, kindb, FFTW_ESTIMATE);
-
-    has_fftw_plan = true;
-
-    int nerror = 0;
-    if (master.get_mpiid() == 0)
-    {
-        char filename[256];
-        std::sprintf(filename, "%s.%07d", "fftwplan", 0);
-
-        master.print_message("Saving \"%s\" ... ", filename);
-
-        int n = fftwf_export_wisdom_to_filename(filename);
-        if (n == 0)
-        {
-            master.print_message("FAILED\n");
-            nerror++;
-        }
-        else
-            master.print_message("OK\n");
-    }
-
-    master.sum(&nerror, 1);
-
-    if (nerror)
-        throw std::runtime_error("Error saving FFTW plan");
-    #endif
-}
 
 namespace
 {
     template<typename> void fftw_execute_wrapper(const fftw_plan&, const fftwf_plan&);
 
+    #ifdef FLOAT_SINGLE
+    template<>
+    void fftw_execute_wrapper<float>(const fftw_plan& p, const fftwf_plan& pf)
+    {
+        fftwf_execute(pf);
+    }
+    #else
     template<>
     void fftw_execute_wrapper<double>(const fftw_plan& p, const fftwf_plan& pf)
     {
         fftw_execute(p);
     }
-
-    template<>
-    void fftw_execute_wrapper<float>(const fftw_plan& p, const fftwf_plan& pf)
-    {
-        #ifdef FLOAT_SINGLE
-        fftwf_execute(pf);
-        #endif
-    }
+    #endif
 
     #ifndef USEMPI
     template<typename TF>

--- a/src/field3d.cu
+++ b/src/field3d.cu
@@ -59,5 +59,9 @@ void Field3d<TF>::clear_device()
     cuda_safe_call(cudaFree(fld_mean_g));
 }
 
-template class Field3d<double>;
+
+#ifdef FLOAT_SINGLE
 template class Field3d<float>;
+#else
+template class Field3d<double>;
+#endif

--- a/src/field3d.cxx
+++ b/src/field3d.cxx
@@ -105,5 +105,9 @@ int Field3d<TF>::init()
     return 0;
 }
 
-template class Field3d<double>;
+
+#ifdef FLOAT_SINGLE
 template class Field3d<float>;
+#else
+template class Field3d<double>;
+#endif

--- a/src/field3d_io.cxx
+++ b/src/field3d_io.cxx
@@ -900,5 +900,9 @@ int Field3d_io<TF>::load_xy_slice(
 }
 #endif
 
-template class Field3d_io<double>;
+
+#ifdef FLOAT_SINGLE
 template class Field3d_io<float>;
+#else
+template class Field3d_io<double>;
+#endif

--- a/src/field3d_operators.cu
+++ b/src/field3d_operators.cu
@@ -211,5 +211,9 @@ TF Field3d_operators<TF>::calc_max_g(const TF* const restrict fld)
 }
 #endif
 
-template class Field3d_operators<double>;
+
+#ifdef FLOAT_SINGLE
 template class Field3d_operators<float>;
+#else
+template class Field3d_operators<double>;
+#endif

--- a/src/field3d_operators.cxx
+++ b/src/field3d_operators.cxx
@@ -154,5 +154,9 @@ TF Field3d_operators<TF>::calc_mean(const TF* const restrict fld)
     return mean;
 }
 
-template class Field3d_operators<double>;
+
+#ifdef FLOAT_SINGLE
 template class Field3d_operators<float>;
+#else
+template class Field3d_operators<double>;
+#endif

--- a/src/fields.cu
+++ b/src/fields.cu
@@ -632,5 +632,9 @@ void Fields<TF>::exec_column(Column<TF>& column)
 }
 #endif
 
-template class Fields<double>;
+
+#ifdef FLOAT_SINGLE
 template class Fields<float>;
+#else
+template class Fields<double>;
+#endif

--- a/src/fields.cxx
+++ b/src/fields.cxx
@@ -1398,5 +1398,8 @@ void Fields<TF>::reset_tendencies()
 }
 
 
-template class Fields<double>;
+#ifdef FLOAT_SINGLE
 template class Fields<float>;
+#else
+template class Fields<double>;
+#endif

--- a/src/force.cu
+++ b/src/force.cu
@@ -518,5 +518,9 @@ void Force<TF>::update_time_dependent(Timeloop<TF>& timeloop)
 }
 #endif
 
-template class Force<double>;
+
+#ifdef FLOAT_SINGLE
 template class Force<float>;
+#else
+template class Force<double>;
+#endif

--- a/src/force.cxx
+++ b/src/force.cxx
@@ -751,5 +751,9 @@ void Force<TF>::update_time_dependent(Timeloop<TF>& timeloop)
 }
 #endif
 
-template class Force<double>;
+
+#ifdef FLOAT_SINGLE
 template class Force<float>;
+#else
+template class Force<double>;
+#endif

--- a/src/grid.cu
+++ b/src/grid.cu
@@ -73,5 +73,9 @@ void Grid<TF>::clear_device()
     cuda_safe_call(cudaFree(gd.dzhi4_g));
 }
 
-template class Grid<double>;
+
+#ifdef FLOAT_SINGLE
 template class Grid<float>;
+#else
+template class Grid<double>;
+#endif

--- a/src/grid.cxx
+++ b/src/grid.cxx
@@ -578,5 +578,9 @@ void Grid<TF>::interpolate_4th(TF* restrict out, const TF* restrict in, const in
 //         prof[k] /= n;
 // }
 
-template class Grid<double>;
+
+#ifdef FLOAT_SINGLE
 template class Grid<float>;
+#else
+template class Grid<double>;
+#endif

--- a/src/grid_parallel.cxx
+++ b/src/grid_parallel.cxx
@@ -186,6 +186,11 @@ void Grid<TF>::load_grid()
     calculate();
 }
 
-template class Grid<double>;
+
+#ifdef FLOAT_SINGLE
 template class Grid<float>;
+#else
+template class Grid<double>;
+#endif
+
 #endif

--- a/src/grid_serial.cxx
+++ b/src/grid_serial.cxx
@@ -116,6 +116,11 @@ void Grid<TF>::load_grid()
     calculate();
 }
 
-template class Grid<double>;
+
+#ifdef FLOAT_SINGLE
 template class Grid<float>;
+#else
+template class Grid<double>;
+#endif
+
 #endif

--- a/src/immersed_boundary.cu
+++ b/src/immersed_boundary.cu
@@ -282,5 +282,9 @@ void Immersed_boundary<TF>::clear_device()
     }
 }
 
-template class Immersed_boundary<double>;
+
+#ifdef FLOAT_SINGLE
 template class Immersed_boundary<float>;
+#else
+template class Immersed_boundary<double>;
+#endif

--- a/src/immersed_boundary.cxx
+++ b/src/immersed_boundary.cxx
@@ -985,5 +985,8 @@ void Immersed_boundary<TF>::exec_cross(Cross<TF>& cross, unsigned long iotime)
 }
 
 
-template class Immersed_boundary<double>;
+#ifdef FLOAT_SINGLE
 template class Immersed_boundary<float>;
+#else
+template class Immersed_boundary<double>;
+#endif

--- a/src/input.cxx
+++ b/src/input.cxx
@@ -430,6 +430,7 @@ std::vector<T> Input::get_list(const std::string& blockname,
     }
 }
 
+
 // Explicitly instantiate templates.
 template bool Input::get_item<bool>(const std::string&, const std::string&, const std::string&);
 template int Input::get_item<int>(const std::string&, const std::string&, const std::string&);

--- a/src/limiter.cu
+++ b/src/limiter.cu
@@ -95,5 +95,9 @@ void Limiter<TF>::exec(double dt, Stats<TF>& stats)
 }
 #endif
 
-template class Limiter<double>;
+
+#ifdef FLOAT_SINGLE
 template class Limiter<float>;
+#else
+template class Limiter<double>;
+#endif

--- a/src/limiter.cxx
+++ b/src/limiter.cxx
@@ -93,5 +93,9 @@ void Limiter<TF>::exec(double dt, Stats<TF>& stats)
 }
 #endif
 
-template class Limiter<double>;
+
+#ifdef FLOAT_SINGLE
 template class Limiter<float>;
+#else
+template class Limiter<double>;
+#endif

--- a/src/microphys.cxx
+++ b/src/microphys.cxx
@@ -68,5 +68,9 @@ std::shared_ptr<Microphys<TF>> Microphys<TF>::factory(Master& masterin, Grid<TF>
     }
 }
 
-template class Microphys<double>;
+
+#ifdef FLOAT_SINGLE
 template class Microphys<float>;
+#else
+template class Microphys<double>;
+#endif

--- a/src/microphys_2mom_warm.cu
+++ b/src/microphys_2mom_warm.cu
@@ -696,5 +696,9 @@ void Microphys_2mom_warm<TF>::clear_device()
 }
 #endif
 
-template class Microphys_2mom_warm<double>;
+
+#ifdef FLOAT_SINGLE
 template class Microphys_2mom_warm<float>;
+#else
+template class Microphys_2mom_warm<double>;
+#endif

--- a/src/microphys_2mom_warm.cxx
+++ b/src/microphys_2mom_warm.cxx
@@ -1023,5 +1023,9 @@ void Microphys_2mom_warm<TF>::get_surface_rain_rate(std::vector<TF>& field)
     field = rr_bot;
 }
 
-template class Microphys_2mom_warm<double>;
+
+#ifdef FLOAT_SINGLE
 template class Microphys_2mom_warm<float>;
+#else
+template class Microphys_2mom_warm<double>;
+#endif

--- a/src/microphys_disabled.cu
+++ b/src/microphys_disabled.cu
@@ -36,5 +36,9 @@ void Microphys_disabled<TF>::get_surface_rain_rate_g(
 }
 #endif
 
-template class Microphys_disabled<double>;
+
+#ifdef FLOAT_SINGLE
 template class Microphys_disabled<float>;
+#else
+template class Microphys_disabled<double>;
+#endif

--- a/src/microphys_disabled.cxx
+++ b/src/microphys_disabled.cxx
@@ -53,5 +53,9 @@ void Microphys_disabled<TF>::get_surface_rain_rate(std::vector<TF>& field)
     std::fill(field.begin(), field.end(), TF(0));
 }
 
-template class Microphys_disabled<double>;
+
+#ifdef FLOAT_SINGLE
 template class Microphys_disabled<float>;
+#else
+template class Microphys_disabled<double>;
+#endif

--- a/src/microphys_nsw6.cu
+++ b/src/microphys_nsw6.cu
@@ -1008,5 +1008,9 @@ void Microphys_nsw6<TF>::clear_device()
 }
 #endif
 
-template class Microphys_nsw6<double>;
+
+#ifdef FLOAT_SINGLE
 template class Microphys_nsw6<float>;
+#else
+template class Microphys_nsw6<double>;
+#endif

--- a/src/microphys_nsw6.cxx
+++ b/src/microphys_nsw6.cxx
@@ -1201,5 +1201,9 @@ void Microphys_nsw6<TF>::get_surface_rain_rate(std::vector<TF>& field)
     std::transform(field.begin(), field.end(), rg_bot.begin(), field.begin(), std::plus<TF>());
 }
 
-template class Microphys_nsw6<double>;
+
+#ifdef FLOAT_SINGLE
 template class Microphys_nsw6<float>;
+#else
+template class Microphys_nsw6<double>;
+#endif

--- a/src/pres.cu
+++ b/src/pres.cu
@@ -517,5 +517,9 @@ void Pres<TF>::check_cufft_memory()
 }
 #endif
 
-template class Pres<double>;
+
+#ifdef FLOAT_SINGLE
 template class Pres<float>;
+#else
+template class Pres<double>;
+#endif

--- a/src/pres.cxx
+++ b/src/pres.cxx
@@ -83,5 +83,9 @@ std::shared_ptr<Pres<TF>> Pres<TF>::factory(
     }
 }
 
-template class Pres<double>;
+
+#ifdef FLOAT_SINGLE
 template class Pres<float>;
+#else
+template class Pres<double>;
+#endif

--- a/src/pres_2.cu
+++ b/src/pres_2.cu
@@ -370,5 +370,9 @@ TF Pres_2<TF>::check_divergence()
 }
 #endif
 
-template class Pres_2<double>;
+
+#ifdef FLOAT_SINGLE
 template class Pres_2<float>;
+#else
+template class Pres_2<double>;
+#endif

--- a/src/pres_2.cxx
+++ b/src/pres_2.cxx
@@ -422,5 +422,9 @@ TF Pres_2<TF>::calc_divergence(const TF* const restrict u, const TF* const restr
 }
 #endif
 
-template class Pres_2<double>;
+
+#ifdef FLOAT_SINGLE
 template class Pres_2<float>;
+#else
+template class Pres_2<double>;
+#endif

--- a/src/pres_4.cu
+++ b/src/pres_4.cu
@@ -657,5 +657,9 @@ TF Pres_4<TF>::check_divergence()
 }
 #endif
 
-template class Pres_4<double>;
+
+#ifdef FLOAT_SINGLE
 template class Pres_4<float>;
+#else
+template class Pres_4<double>;
+#endif

--- a/src/pres_4.cxx
+++ b/src/pres_4.cxx
@@ -766,5 +766,9 @@ TF Pres_4<TF>::calc_divergence(
     return divmax;
 }
 
-template class Pres_4<double>;
+
+#ifdef FLOAT_SINGLE
 template class Pres_4<float>;
+#else
+template class Pres_4<double>;
+#endif

--- a/src/pres_disabled.cxx
+++ b/src/pres_disabled.cxx
@@ -61,5 +61,9 @@ template<typename TF>
 void Pres_disabled<TF>::clear_device() {}
 #endif
 
-template class Pres_disabled<double>;
+
+#ifdef FLOAT_SINGLE
 template class Pres_disabled<float>;
+#else
+template class Pres_disabled<double>;
+#endif

--- a/src/radiation.cxx
+++ b/src/radiation.cxx
@@ -81,6 +81,7 @@ std::shared_ptr<Radiation<TF>> Radiation<TF>::factory(
     }
 }
 
+
 #ifdef FLOAT_SINGLE
 template class Radiation<float>;
 #else

--- a/src/radiation_disabled.cxx
+++ b/src/radiation_disabled.cxx
@@ -48,6 +48,7 @@ bool Radiation_disabled<TF>::check_field_exists(const std::string& name)
     return false;  // always returns error
 }
 
+
 #ifdef FLOAT_SINGLE
 template class Radiation_disabled<float>;
 #else

--- a/src/radiation_gcss.cu
+++ b/src/radiation_gcss.cu
@@ -356,6 +356,7 @@ void Radiation_gcss<TF>::get_radiation_field_g(Field3d<TF>& fld, std::string nam
 }
 #endif
 
+
 #ifdef FLOAT_SINGLE
 template class Radiation_gcss<float>;
 #else

--- a/src/radiation_gcss.cxx
+++ b/src/radiation_gcss.cxx
@@ -578,6 +578,7 @@ void Radiation_gcss<TF>::exec_all_stats(
     }
 }
 
+
 #ifdef FLOAT_SINGLE
 template class Radiation_gcss<float>;
 #else

--- a/src/radiation_prescribed.cu
+++ b/src/radiation_prescribed.cu
@@ -151,6 +151,7 @@ void Radiation_prescribed<TF>::backward_device()
 }
 #endif
 
+
 #ifdef FLOAT_SINGLE
 template class Radiation_prescribed<float>;
 #else

--- a/src/radiation_prescribed.cxx
+++ b/src/radiation_prescribed.cxx
@@ -166,6 +166,7 @@ std::vector<TF>& Radiation_prescribed<TF>::get_surface_radiation(const std::stri
     }
 }
 
+
 #ifdef FLOAT_SINGLE
 template class Radiation_prescribed<float>;
 #else

--- a/src/radiation_rrtmgp.cu
+++ b/src/radiation_rrtmgp.cu
@@ -1779,6 +1779,7 @@ void Radiation_rrtmgp<TF>::exec_individual_column_stats(
 }
 #endif
 
+
 #ifdef FLOAT_SINGLE
 template class Radiation_rrtmgp<float>;
 #else

--- a/src/radiation_rrtmgp_rt.cu
+++ b/src/radiation_rrtmgp_rt.cu
@@ -2601,7 +2601,7 @@ void Radiation_rrtmgp_rt<TF>::exec_all_stats(
 #endif
 
 
-#ifdef RT_USE_SP
+#ifdef FLOAT_SINGLE
 template class Radiation_rrtmgp_rt<float>;
 #else
 template class Radiation_rrtmgp_rt<double>;

--- a/src/radiation_rrtmgp_rt.cu
+++ b/src/radiation_rrtmgp_rt.cu
@@ -2600,7 +2600,8 @@ void Radiation_rrtmgp_rt<TF>::exec_all_stats(
 }
 #endif
 
-#ifdef FLOAT_SINGLE
+
+#ifdef RT_USE_SP
 template class Radiation_rrtmgp_rt<float>;
 #else
 template class Radiation_rrtmgp_rt<double>;

--- a/src/radiation_rrtmgp_rt.cxx
+++ b/src/radiation_rrtmgp_rt.cxx
@@ -1450,7 +1450,8 @@ bool Radiation_rrtmgp_rt<TF>::is_day(const Float mu0)
     return false;
 }
 
-#ifdef RTE_USE_SP
+
+#ifdef FLOAT_SINGLE
 template class Radiation_rrtmgp_rt<float>;
 #else
 template class Radiation_rrtmgp_rt<double>;

--- a/src/soil_field3d.cu
+++ b/src/soil_field3d.cu
@@ -53,5 +53,9 @@ void Soil_field3d<TF>::clear_device()
 }
 #endif
 
-template class Soil_field3d<double>;
+
+#ifdef FLOAT_SINGLE
 template class Soil_field3d<float>;
+#else
+template class Soil_field3d<double>;
+#endif

--- a/src/soil_field3d.cxx
+++ b/src/soil_field3d.cxx
@@ -73,5 +73,9 @@ int Soil_field3d<TF>::init()
     return 0;
 }
 
-template class Soil_field3d<double>;
+
+#ifdef FLOAT_SINGLE
 template class Soil_field3d<float>;
+#else
+template class Soil_field3d<double>;
+#endif

--- a/src/soil_grid.cu
+++ b/src/soil_grid.cu
@@ -63,5 +63,9 @@ void Soil_grid<TF>::clear_device()
 }
 #endif
 
-template class Soil_grid<double>;
+
+#ifdef FLOAT_SINGLE
 template class Soil_grid<float>;
+#else
+template class Soil_grid<double>;
+#endif

--- a/src/soil_grid.cxx
+++ b/src/soil_grid.cxx
@@ -143,5 +143,9 @@ const Soil_grid_data<TF>& Soil_grid<TF>::get_grid_data()
     return gd;
 }
 
-template class Soil_grid<double>;
+
+#ifdef FLOAT_SINGLE
 template class Soil_grid<float>;
+#else
+template class Soil_grid<double>;
+#endif

--- a/src/source.cu
+++ b/src/source.cu
@@ -170,5 +170,9 @@ void Source<TF>::exec(Timeloop<TF>& timeloop)
 }
 #endif
 
-template class Source<double>;
+
+#ifdef FLOAT_SINGLE
 template class Source<float>;
+#else
+template class Source<double>;
+#endif

--- a/src/source.cxx
+++ b/src/source.cxx
@@ -546,5 +546,9 @@ TF Source<TF>::calc_norm(
     return sum;
 }
 
-template class Source<double>;
+
+#ifdef FLOAT_SINGLE
 template class Source<float>;
+#else
+template class Source<double>;
+#endif

--- a/src/stats.cxx
+++ b/src/stats.cxx
@@ -2259,5 +2259,9 @@ void Stats<TF>::calc_grad_4th(
     }
 }
 
-template class Stats<double>;
+
+#ifdef FLOAT_SINGLE
 template class Stats<float>;
+#else
+template class Stats<double>;
+#endif

--- a/src/thermo.cxx
+++ b/src/thermo.cxx
@@ -72,5 +72,9 @@ std::shared_ptr<Thermo<TF>> Thermo<TF>::factory(
     }
 }
 
-template class Thermo<double>;
+
+#ifdef FLOAT_SINGLE
 template class Thermo<float>;
+#else
+template class Thermo<double>;
+#endif

--- a/src/thermo_buoy.cu
+++ b/src/thermo_buoy.cu
@@ -529,5 +529,9 @@ void Thermo_buoy<TF>::get_buoyancy_surf_g(Field3d<TF>& b)
 }
 #endif
 
-template class Thermo_buoy<double>;
+
+#ifdef FLOAT_SINGLE
 template class Thermo_buoy<float>;
+#else
+template class Thermo_buoy<double>;
+#endif

--- a/src/thermo_buoy.cxx
+++ b/src/thermo_buoy.cxx
@@ -470,5 +470,9 @@ bool Thermo_buoy<TF>::check_field_exists(std::string name)
         return false;
 }
 
-template class Thermo_buoy<double>;
+
+#ifdef FLOAT_SINGLE
 template class Thermo_buoy<float>;
+#else
+template class Thermo_buoy<double>;
+#endif

--- a/src/thermo_disabled.cxx
+++ b/src/thermo_disabled.cxx
@@ -58,5 +58,9 @@ TF Thermo_disabled<TF>::get_buoyancy_diffusivity()
     return 0.;
 }
 
-template class Thermo_disabled<double>;
+
+#ifdef FLOAT_SINGLE
 template class Thermo_disabled<float>;
+#else
+template class Thermo_disabled<double>;
+#endif

--- a/src/thermo_dry.cu
+++ b/src/thermo_dry.cu
@@ -366,5 +366,10 @@ void Thermo_dry<TF>::exec_column(Column<TF>& column)
     fields.release_tmp_g(output);
 }
 #endif
-template class Thermo_dry<double>;
+
+
+#ifdef FLOAT_SINGLE
 template class Thermo_dry<float>;
+#else
+template class Thermo_dry<double>;
+#endif

--- a/src/thermo_dry.cxx
+++ b/src/thermo_dry.cxx
@@ -845,5 +845,9 @@ void Thermo_dry<TF>::exec_cross(Cross<TF>& cross, unsigned long iotime)
     fields.release_tmp(b);
 }
 
-template class Thermo_dry<double>;
+
+#ifdef FLOAT_SINGLE
 template class Thermo_dry<float>;
+#else
+template class Thermo_dry<double>;
+#endif

--- a/src/thermo_moist.cu
+++ b/src/thermo_moist.cu
@@ -1388,5 +1388,9 @@ void Thermo_moist<TF>::get_land_surface_fields_g(
 }
 #endif
 
-template class Thermo_moist<double>;
+
+#ifdef FLOAT_SINGLE
 template class Thermo_moist<float>;
+#else
+template class Thermo_moist<double>;
+#endif

--- a/src/thermo_moist.cxx
+++ b/src/thermo_moist.cxx
@@ -2319,5 +2319,9 @@ void Thermo_moist<TF>::exec_dump(Dump<TF>& dump, unsigned long iotime)
     fields.release_tmp(output);
 }
 
-template class Thermo_moist<double>;
+
+#ifdef FLOAT_SINGLE
 template class Thermo_moist<float>;
+#else
+template class Thermo_moist<double>;
+#endif

--- a/src/timedep.cu
+++ b/src/timedep.cu
@@ -105,5 +105,9 @@ void Timedep<TF>::update_time_dependent_prof_g(TF* prof, Timeloop<TF>& timeloop,
 }
 #endif
 
-template class Timedep<double>;
+
+#ifdef FLOAT_SINGLE
 template class Timedep<float>;
+#else
+template class Timedep<double>;
+#endif

--- a/src/timedep.cxx
+++ b/src/timedep.cxx
@@ -168,5 +168,9 @@ void Timedep<TF>::update_time_dependent(TF& val, Timeloop<TF>& timeloop)
     return;
 }
 
-template class Timedep<double>;
+
+#ifdef FLOAT_SINGLE
 template class Timedep<float>;
+#else
+template class Timedep<double>;
+#endif

--- a/src/timeloop.cu
+++ b/src/timeloop.cu
@@ -267,5 +267,9 @@ void Timeloop<TF>::exec()
 }
 #endif
 
-template class Timeloop<double>;
+
+#ifdef FLOAT_SINGLE
 template class Timeloop<float>;
+#else
+template class Timeloop<double>;
+#endif

--- a/src/timeloop.cxx
+++ b/src/timeloop.cxx
@@ -644,5 +644,9 @@ Interpolation_factors<TF> Timeloop<TF>::get_interpolation_factors(const std::vec
     return ifac;
 }
 
-template class Timeloop<double>;
+
+#ifdef FLOAT_SINGLE
 template class Timeloop<float>;
+#else
+template class Timeloop<double>;
+#endif

--- a/src/transpose.cxx
+++ b/src/transpose.cxx
@@ -282,5 +282,9 @@ void Transpose<TF>::exit_mpi()
 }
 #endif
 
-template class Transpose<double>;
+
+#ifdef FLOAT_SINGLE
 template class Transpose<float>;
+#else
+template class Transpose<double>;
+#endif


### PR DESCRIPTION
I have put `#ifdef FLOAT_SINGLE` in all source files to only compile single or double precision code, since we only use one or the other. This halfs the compilation time, and halfs the executable size. 111 changed files, good luck with the review :)