### PR TITLE
`cudaFree`'ed the land-surface model.

### DIFF
--- a/include/land_surface_kernels_gpu.h
+++ b/include/land_surface_kernels_gpu.h
@@ -724,6 +724,27 @@ template<typename TF> __global__
     }
 
     template<typename TF>
+    void clear_tile(Surface_tile<TF>& tile)
+    {
+        cuda_safe_call(cudaFree(tile.fraction_g));
+        cuda_safe_call(cudaFree(tile.thl_bot_g));
+        cuda_safe_call(cudaFree(tile.qt_bot_g));
+
+        cuda_safe_call(cudaFree(tile.obuk_g));
+        cuda_safe_call(cudaFree(tile.ustar_g));
+        cuda_safe_call(cudaFree(tile.bfluxbot_g));
+        cuda_safe_call(cudaFree(tile.ra_g));
+
+        cuda_safe_call(cudaFree(tile.nobuk_g));
+
+        cuda_safe_call(cudaFree(tile.rs_g));
+        cuda_safe_call(cudaFree(tile.H_g));
+        cuda_safe_call(cudaFree(tile.LE_g));
+        cuda_safe_call(cudaFree(tile.G_g));
+        cuda_safe_call(cudaFree(tile.S_g));
+    }
+
+    template<typename TF>
     void forward_device_tile(Surface_tile<TF>& tile, const int ijcells)
     {
         const int memsize_tf  = ijcells * sizeof(TF);

--- a/src/boundary_surface_lsm.cu
+++ b/src/boundary_surface_lsm.cu
@@ -1095,7 +1095,6 @@ void Boundary_surface_lsm<TF>::clear_device(Thermo<TF>& thermo)
     //
     // De-llocate fields on GPU
     //
-    // Monin-Obukhov stuff:
     cuda_safe_call(cudaFree(obuk_g));
     cuda_safe_call(cudaFree(ustar_g));
 
@@ -1112,7 +1111,57 @@ void Boundary_surface_lsm<TF>::clear_device(Thermo<TF>& thermo)
         cuda_safe_call(cudaFree(zL_sl_g));
         cuda_safe_call(cudaFree(f_sl_g));
     }
-    // Land-surface stuff:
+
+    // Land-surface:
+    for (auto& tile : tiles)
+        lsmk::clear_tile(tile.second);
+
+    cuda_safe_call(cudaFree(gD_coeff_g));
+    cuda_safe_call(cudaFree(c_veg_g));
+    cuda_safe_call(cudaFree(lai_g));
+    cuda_safe_call(cudaFree(rs_veg_min_g));
+    cuda_safe_call(cudaFree(rs_soil_min_g));
+    cuda_safe_call(cudaFree(lambda_stable_g));
+    cuda_safe_call(cudaFree(lambda_unstable_g));
+    cuda_safe_call(cudaFree(cs_veg_g));
+
+    if (sw_water)
+    {
+        cuda_safe_call(cudaFree(water_mask_g));
+        cuda_safe_call(cudaFree(t_bot_water_g));
+    }
+
+    cuda_safe_call(cudaFree(interception_g));
+    cuda_safe_call(cudaFree(throughfall_g));
+    cuda_safe_call(cudaFree(infiltration_g));
+    cuda_safe_call(cudaFree(runoff_g));
+
+    cuda_safe_call(cudaFree(soil_index_g));
+    cuda_safe_call(cudaFree(diffusivity_g));
+    cuda_safe_call(cudaFree(diffusivity_h_g));
+    cuda_safe_call(cudaFree(conductivity_g));
+    cuda_safe_call(cudaFree(conductivity_h_g));
+    cuda_safe_call(cudaFree(source_g));
+    cuda_safe_call(cudaFree(root_fraction_g));
+
+    cuda_safe_call(cudaFree(theta_res_g));
+    cuda_safe_call(cudaFree(theta_wp_g));
+    cuda_safe_call(cudaFree(theta_fc_g));
+    cuda_safe_call(cudaFree(theta_sat_g));
+
+    cuda_safe_call(cudaFree(gamma_theta_sat_g));
+
+    cuda_safe_call(cudaFree(vg_a_g));
+    cuda_safe_call(cudaFree(vg_l_g));
+    cuda_safe_call(cudaFree(vg_n_g));
+    cuda_safe_call(cudaFree(vg_m_g));
+
+    cuda_safe_call(cudaFree(kappa_theta_max_g));
+    cuda_safe_call(cudaFree(kappa_theta_min_g));
+    cuda_safe_call(cudaFree(gamma_theta_max_g));
+    cuda_safe_call(cudaFree(gamma_theta_min_g));
+    cuda_safe_call(cudaFree(gamma_T_dry_g));
+    cuda_safe_call(cudaFree(rho_C_g));
 }
 #endif
 


### PR DESCRIPTION
At least the land-surface is leak free now, but MicroHH overall isn't. `compute-sanitizer` is also reporting leaks of the nudge `timedep` profiles (only those, the others `timedep`'s from force are not leaking), but I can't find the error there. The `timedep->clear_device()` functions are called for those `timedep`'s at the end of the simulation.