### PR TITLE
Timedep nudge fix; no more leaks!

### DIFF
--- a/include/microphys_disabled.h
+++ b/include/microphys_disabled.h
@@ -23,6 +23,7 @@
 #ifndef MICROPHYS_DISABLED_H
 #define MICROPHYS_DISABLED_H
 
+#include <stdexcept>
 #include "microphys.h"
 
 class Master;

--- a/src/force.cxx
+++ b/src/force.cxx
@@ -531,7 +531,7 @@ void Force<TF>::create(Input& inputin, Netcdf_handle& input_nc, Stats<TF>& stats
         // Read the nudging profiles, which are the variable names with a "nudge" suffix
         for (auto& it : nudgelist)
         {
-            if (tdep_nudge.find(it)==tdep_nudge.end())
+            if (tdep_nudge.find(it) == tdep_nudge.end())
             {
                 group_nc.get_variable(nudgeprofs[it], it+"_nudge", {0}, {gd.ktot});
                 std::rotate(nudgeprofs[it].rbegin(), nudgeprofs[it].rbegin() + gd.kstart, nudgeprofs[it].rend());
@@ -543,21 +543,17 @@ void Force<TF>::create(Input& inputin, Netcdf_handle& input_nc, Stats<TF>& stats
             }
             else
             {
-                // Process the time dependent data
-                for (auto& it : tdep_nudge)
-                {
-                    // Account for the Galilean transformation
-                    TF offset;
-                    if (it.first == "u")
-                        offset = -gd.utrans;
-                    else if (it.first == "v")
-                        offset = -gd.vtrans;
-                    else
-                        offset = 0;
+                // Account for the Galilean transformation
+                TF offset;
+                if (it == "u")
+                    offset = -gd.utrans;
+                else if (it == "v")
+                    offset = -gd.vtrans;
+                else
+                    offset = 0;
 
-                    it.second->create_timedep_prof(input_nc, offset, timedep_dim);
-                    stats.add_tendency(*fields.at.at(it.first), "z", tend_name_nudge, tend_longname_nudge);
-                }
+                tdep_nudge.at(it)->create_timedep_prof(input_nc, offset, timedep_dim);
+                stats.add_tendency(*fields.at.at(it), "z", tend_name_nudge, tend_longname_nudge);
             }
         }
     }

--- a/src/timedep.cxx
+++ b/src/timedep.cxx
@@ -91,7 +91,6 @@ void Timedep<TF>::create_timedep(Netcdf_handle& input_nc, const std::string time
     group_nc.get_variable(time, time_dim, {0}, {time_dim_length});
     group_nc.get_variable(data, varname,  {0}, {time_dim_length});
 
-
     #ifdef USECUDA
     prepare_device();
     #endif


### PR DESCRIPTION
Bugfix timedep nudging; there was a nested loop, where for each item in `nudgelist`, all items in `tdep_nudge` were created. Additionally adds a missing include in `microphys_disabled.h`.