### PR TITLE
microhh_tools copying of auxilary files

### DIFF
--- a/python/microhh_tools.py
+++ b/python/microhh_tools.py
@@ -1042,35 +1042,46 @@ def run_restart(
             return 1
     return 0
 
-def copy_radfiles(srcdir=None, destdir=None, gpt='128_112'):
+def copy_or_link(src, dst, link = False):
+    if os.path.exists(dst):
+        os.remove(dst)
+    if link:
+        os.symlink(src, dst)
+        print("Linking ",end="")
+    else:
+        shutil.copy(src, dst)
+        print("Copying ",end="")
+    print(src," to ",dst)
+
+def copy_radfiles(srcdir = None, destdir = None, gpt = '128_112', link = False):
     if srcdir is None:
         srcdir = os.path.dirname(inspect.getabsfile(inspect.currentframe()))+'/../rte-rrtmgp-cpp/rrtmgp-data/' 
     if destdir is None:
         destdir = os.getcwd()
     if gpt == '128_112':
-        shutil.copy(srcdir+'rrtmgp-gas-lw-g128.nc', destdir+'/coefficients_lw.nc')
-        shutil.copy(srcdir+'rrtmgp-gas-sw-g112.nc', destdir+'/coefficients_sw.nc')
+        copy_or_link(srcdir + 'rrtmgp-gas-lw-g128.nc', destdir + '/coefficients_lw.nc', link = link)
+        copy_or_link(srcdir + 'rrtmgp-gas-sw-g112.nc', destdir + '/coefficients_sw.nc', link = link)
     elif gpt == '256_224':
-        shutil.copy(srcdir+'rrtmgp-gas-lw-g256.nc', destdir+'/coefficients_lw.nc')
-        shutil.copy(srcdir+'rrtmgp-gas-sw-g224.nc', destdir+'/coefficients_sw.nc')
+        copy_or_link(srcdir + 'rrtmgp-gas-lw-g256.nc', destdir + '/coefficients_lw.nc', link = link)
+        copy_or_link(srcdir + 'rrtmgp-gas-sw-g224.nc', destdir + '/coefficients_sw.nc', link = link)
     else:
         raise ValueError('gpt should be in {\'128_112\', \'256_224\'}')
 
-    shutil.copy(srcdir+'rrtmgp-clouds-lw.nc', destdir+'/cloud_coefficients_lw.nc')
-    shutil.copy(srcdir+'rrtmgp-clouds-sw.nc', destdir+'/cloud_coefficients_sw.nc')
+    copy_or_link(srcdir + 'rrtmgp-clouds-lw.nc', destdir + '/cloud_coefficients_lw.nc', link = link)
+    copy_or_link(srcdir + 'rrtmgp-clouds-sw.nc', destdir + '/cloud_coefficients_sw.nc', link = link)
 
-def copy_aerosolfiles(srcdir=None, destdir=None):
+def copy_aerosolfiles(srcdir = None, destdir = None, link = False):
     if srcdir is None:
-        srcdir = os.path.dirname(inspect.getabsfile(inspect.currentframe()))+'/../rte-rrtmgp-cpp/data/' 
+        srcdir = os.path.dirname(inspect.getabsfile(inspect.currentframe())) + '/../rte-rrtmgp-cpp/data/' 
     if destdir is None:
         destdir = os.getcwd()
 
-    shutil.copy(srcdir+'aerosol_optics.nc', destdir+ 'aerosol_optics.nc')
+    copy_or_link(srcdir + 'aerosol_optics.nc', destdir + 'aerosol_optics.nc', link = link)
 
-def copy_lsmfiles(srcdir=None, destdir=None):
+def copy_lsmfiles(srcdir = None, destdir = None, link = False):
     if srcdir is None:
         srcdir = os.path.dirname(inspect.getabsfile(inspect.currentframe()))+'/../misc/'
     if destdir is None:
         destdir = os.getcwd()
-    shutil.copy(srcdir+'van_genuchten_parameters.nc', destdir)
+    copy_or_link(srcdir+'van_genuchten_parameters.nc', destdir, link = link)
     

--- a/python/microhh_tools.py
+++ b/python/microhh_tools.py
@@ -36,6 +36,7 @@ import csv
 import copy
 import datetime
 import itertools
+import inspect
 from copy import deepcopy
 
 # -------------------------

--- a/python/microhh_tools.py
+++ b/python/microhh_tools.py
@@ -1044,20 +1044,28 @@ def run_restart(
 
 def copy_radfiles(srcdir=None, destdir=None, gpt='128_112'):
     if srcdir is None:
-        srcdir = os.path.dirname(inspect.getabsfile(inspect.currentframe()))+'/../rte-rrtmgp-cpp/rte-rrtmgp/' 
+        srcdir = os.path.dirname(inspect.getabsfile(inspect.currentframe()))+'/../rte-rrtmgp-cpp/rrtmgp-data/' 
     if destdir is None:
         destdir = os.getcwd()
     if gpt == '128_112':
-        shutil.copy(srcdir+'rrtmgp/data/rrtmgp-data-lw-g128-210809.nc', destdir+'/coefficients_lw.nc')
-        shutil.copy(srcdir+'rrtmgp/data/rrtmgp-data-sw-g112-210809.nc', destdir+'/coefficients_sw.nc')
+        shutil.copy(srcdir+'rrtmgp-gas-lw-g128.nc', destdir+'/coefficients_lw.nc')
+        shutil.copy(srcdir+'rrtmgp-gas-sw-g112.nc', destdir+'/coefficients_sw.nc')
     elif gpt == '256_224':
-        shutil.copy(srcdir+'rrtmgp/data/rrtmgp-data-lw-g256-210809.nc', destdir+'/coefficients_lw.nc')
-        shutil.copy(srcdir+'rrtmgp/data/rrtmgp-data-sw-g224-210809.nc', destdir+'/coefficients_sw.nc')
+        shutil.copy(srcdir+'rrtmgp-gas-lw-g256.nc', destdir+'/coefficients_lw.nc')
+        shutil.copy(srcdir+'rrtmgp-gas-sw-g224.nc', destdir+'/coefficients_sw.nc')
     else:
         raise ValueError('gpt should be in {\'128_112\', \'256_224\'}')
 
-    shutil.copy(srcdir+'extensions/cloud_optics/rrtmgp-cloud-optics-coeffs-lw.nc', destdir+'/cloud_coefficients_lw.nc')
-    shutil.copy(srcdir+'extensions/cloud_optics/rrtmgp-cloud-optics-coeffs-sw.nc', destdir+'/cloud_coefficients_sw.nc')
+    shutil.copy(srcdir+'rrtmgp-clouds-lw.nc', destdir+'/cloud_coefficients_lw.nc')
+    shutil.copy(srcdir+'rrtmgp-clouds-sw.nc', destdir+'/cloud_coefficients_sw.nc')
+
+def copy_aerosolfiles(srcdir=None, destdir=None):
+    if srcdir is None:
+        srcdir = os.path.dirname(inspect.getabsfile(inspect.currentframe()))+'/../rte-rrtmgp-cpp/data/' 
+    if destdir is None:
+        destdir = os.getcwd()
+
+    shutil.copy(srcdir+'aerosol_optics.nc', destdir+ 'aerosol_optics.nc')
 
 def copy_lsmfiles(srcdir=None, destdir=None):
     if srcdir is None:


### PR DESCRIPTION
Fixes https://github.com/microhh/microhh/issues/129
Copy the radiation, lsm, and aerosol files to the run dir using the microhh_tools.