### PR TITLE
Pulling # of background levels in stat from background

### DIFF
--- a/include/background_profs.h
+++ b/include/background_profs.h
@@ -44,6 +44,8 @@ public:
     void get_gasses(Gas_concs&);
     void get_aerosols(Aerosol_concs&);
 
+    int get_n_era_levels() const { return n_era_levels; }
+
 private:
     Master& master;
     Grid<TF>& grid;

--- a/include/stats.h
+++ b/include/stats.h
@@ -31,6 +31,7 @@ class Input;
 class Netcdf_file;
 template<typename> class Grid;
 template<typename> class Soil_grid;
+template<typename> class Background;
 template<typename> class Fields;
 template<typename> class Field3d;
 template<typename> class Advec;
@@ -95,7 +96,7 @@ template<typename TF>
 class Stats
 {
     public:
-        Stats(Master&, Grid<TF>&, Soil_grid<TF>&, Fields<TF>&, Advec<TF>&, Diff<TF>&, Input&);
+        Stats(Master&, Grid<TF>&, Soil_grid<TF>&, Background<TF>&, Fields<TF>&, Advec<TF>&, Diff<TF>&, Input&);
         ~Stats();
 
         void init(double);
@@ -170,6 +171,7 @@ class Stats
         Master& master;
         Grid<TF>& grid;
         Soil_grid<TF>& soil_grid;
+        Background<TF>& background;
         Fields<TF>& fields;
         Advec<TF>& advec;
         Diff<TF>& diff;

--- a/src/model.cxx
+++ b/src/model.cxx
@@ -145,7 +145,7 @@ Model<TF>::Model(Master& masterin, int argc, char *argv[]) :
 
         ib        = std::make_shared<Immersed_boundary<TF>>(master, *grid, *fields, *input);
 
-        stats     = std::make_shared<Stats <TF>>(master, *grid, *soil_grid, *fields, *advec, *diff, *input);
+        stats     = std::make_shared<Stats <TF>>(master, *grid, *soil_grid, *background, *fields, *advec, *diff, *input);
         column    = std::make_shared<Column<TF>>(master, *grid, *fields, *input);
         dump      = std::make_shared<Dump  <TF>>(master, *grid, *fields, *input);
         cross     = std::make_shared<Cross <TF>>(master, *grid, *soil_grid, *fields, *input);

--- a/src/stats.cxx
+++ b/src/stats.cxx
@@ -33,6 +33,7 @@
 #include "master.h"
 #include "grid.h"
 #include "soil_grid.h"
+#include "background_profs.h"
 #include "fields.h"
 #include "stats.h"
 #include "defines.h"
@@ -536,9 +537,9 @@ namespace
 
 template<typename TF>
 Stats<TF>::Stats(
-        Master& masterin, Grid<TF>& gridin, Soil_grid<TF>& soilgridin,
+        Master& masterin, Grid<TF>& gridin, Soil_grid<TF>& soilgridin, Background<TF>& backgroundin,
         Fields<TF>& fieldsin, Advec<TF>& advecin, Diff<TF>& diffin, Input& inputin):
-    master(masterin), grid(gridin), soil_grid(soilgridin), fields(fieldsin), advec(advecin), diff(diffin),
+    master(masterin), grid(gridin), soil_grid(soilgridin), background(backgroundin), fields(fieldsin), advec(advecin), diff(diffin),
     boundary_cyclic(master, grid)
 
 {
@@ -1105,7 +1106,7 @@ void Stats<TF>::add_prof(
         }
         else if ((zloc == "era_levels") || (zloc == "era_layers"))
         {
-           const TF n_era_levels = 137;
+            const TF n_era_levels = background.get_n_era_levels();
             Prof_var<TF> tmp{handle.add_variable<TF>(name, {"time", zloc}), std::vector<TF>(n_era_levels), level};
 
             m.background_profs.emplace(std::piecewise_construct, std::forward_as_tuple(name), std::forward_as_tuple(std::move(tmp)));


### PR DESCRIPTION
The number of era_levels is no longer hard coded in stat, but pulled from background_prof instead