### PR TITLE
Lat/lon will now only be read from grid

### DIFF
--- a/cases/cabauw/cabauw_rt.ini.base
+++ b/cases/cabauw/cabauw_rt.ini.base
@@ -14,6 +14,8 @@ ysize=None
 zsize=None
 utrans=0.0
 vtrans=0.0
+lat=51.971
+lon=4.927
 swspatialorder=2
 
 [advec]
@@ -48,8 +50,7 @@ sfc_alb_dir=0.22
 sfc_alb_dif=0.22
 swclearskystats=0
 swfixedsza=0
-lat=51.971
-lon=4.927
+
 
 [boundary]
 swboundary=surface_lsm

--- a/src/grid.cxx
+++ b/src/grid.cxx
@@ -61,8 +61,8 @@ Grid<TF>::Grid(Master& masterin, Input& input) :
     gd.utrans = input.get_item<TF>("grid", "utrans", "", 0.);
     gd.vtrans = input.get_item<TF>("grid", "vtrans", "", 0.);
 
-    gd.lat = input.get_item<TF>("grid", "lat", "",  input.get_item<TF>("radiation", "lat", "", 0.)); //As a legacy option, the latitude can be read from the radiation section
-    gd.lon = input.get_item<TF>("grid", "lon", "",  input.get_item<TF>("radiation", "lon", "", 0.)); //As a legacy option, the longitude can be read from the radiation section
+    gd.lat = input.get_item<TF>("grid", "lat", "",  0.); 
+    gd.lon = input.get_item<TF>("grid", "lon", "",  0.); 
 
     std::string swspatialorder = input.get_item<std::string>("grid", "swspatialorder", "");
 


### PR DESCRIPTION
For the new 2.0 release it seems appropriate to not have the legacy option to have lat/lon in the radiation ini block