### PR TITLE
Allow disabled microphys to return `Nc0` and `Ni0` for LES with

### DIFF
--- a/include/microphys_disabled.h
+++ b/include/microphys_disabled.h
@@ -57,11 +57,10 @@ class Microphys_disabled : public Microphys<TF>
         bool has_mask(std::string) {return false;};
 
         void get_surface_rain_rate(std::vector<TF>&);
-
         unsigned long get_time_limit(unsigned long, double);
 
-        TF get_Nc0() { throw std::runtime_error("Microphys_disabled cannot provide Nc0"); };
-        TF get_Ni0() { throw std::runtime_error("Microphys_disabled cannot provide Ni0"); };
+        TF get_Nc0();
+        TF get_Ni0();
 
         #ifdef USECUDA
         void get_surface_rain_rate_g(TF*);
@@ -73,5 +72,8 @@ class Microphys_disabled : public Microphys<TF>
     private:
         using Microphys<TF>::swmicrophys;
         using Microphys<TF>::grid;
+
+        TF Nc0;
+        TF Ni0;
 };
 #endif

--- a/src/microphys_disabled.cxx
+++ b/src/microphys_disabled.cxx
@@ -34,6 +34,9 @@ Microphys_disabled<TF>::Microphys_disabled(Master& masterin, Grid<TF>& gridin, F
     Microphys<TF>(masterin, gridin, fieldsin, inputin)
 {
     swmicrophys = Microphys_type::Disabled;
+
+    Nc0 = inputin.get_item<TF>("micro", "Nc0", "", -1);
+    Ni0 = inputin.get_item<TF>("micro", "Ni0", "", -1);
 }
 
 template<typename TF>
@@ -53,6 +56,23 @@ void Microphys_disabled<TF>::get_surface_rain_rate(std::vector<TF>& field)
     std::fill(field.begin(), field.end(), TF(0));
 }
 
+template<typename TF>
+TF Microphys_disabled<TF>::get_Nc0()
+{
+    if (this->Nc0 > 0)
+        return this->Nc0;
+    else
+        throw std::runtime_error("Requested uninitialised Nc0!");
+}
+
+template<typename TF>
+TF Microphys_disabled<TF>::get_Ni0()
+{
+    if (this->Ni0 > 0)
+        return this->Ni0;
+    else
+        throw std::runtime_error("Requested uninitialised Ni0!");
+}
 
 #ifdef FLOAT_SINGLE
 template class Microphys_disabled<float>;


### PR DESCRIPTION
IMHO this is the least ugly solution; creating an entire `microphys_fixed_Nc0_Ni0` (...) class only to return two constants seems a bit overkill. I made `Nc0` and `Ni0` optional in `microphys_disabled` (defaulting to `-1`), but if they are requested and not initialized, an error is thrown.