### PR TITLE
Disable `clang-tidy` in Kernel Launcher by default.

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -3,4 +3,5 @@
 	url = https://github.com/microhh/rte-rrtmgp-cpp
 [submodule "external/kernel_launcher"]
 	path = external/kernel_launcher
-	url = https://github.com/KernelTuner/kernel_launcher
+    #url = https://github.com/KernelTuner/kernel_launcher
+	url = https://github.com/microhh/kernel_launcher

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -79,7 +79,6 @@ else()
   project(microhhc CXX Fortran)
 endif()
 
-
 # Display status messages for MPI set precompiler flags.
 if(USEMPI)
   message(STATUS "MPI: Enabled.")
@@ -166,6 +165,13 @@ endif()
 
 if(USECUDA)
   if(USEKERNELLAUNCHER)
+    # Set `clang-tidy` flag for Kernel Launcher
+    if (NOT USECLANGTIDY)
+      set(DISABLE_CLANG_TIDY TRUE)
+    else()
+      set(DISABLE_CLANG_TIDY FALSE)
+    endif()
+
     add_compile_definitions(ENABLE_KERNEL_LAUNCHER)
     add_subdirectory(external/kernel_launcher)
   endif()


### PR DESCRIPTION
One option to git rid of `clang-tidy`:
- Made a fork of `kernel_launcher` in the MicroHH organisation;
- On the `kernel_launcher` side, compilation/CMake defaults to using `clang-tidy`;
- On the MicroHH side the default is the opposite: unless `-DUSECLANGTIDY=true` is set, `clang-tidy` is disabled.