### PR TITLE
Valgrind stats

### DIFF
--- a/src/boundary_surface_bulk.cxx
+++ b/src/boundary_surface_bulk.cxx
@@ -129,6 +129,7 @@ void Boundary_surface_bulk<TF>::create(
     const std::string group_name = "default";
 
     Boundary<TF>::process_time_dependent(input, input_nc, timeloop);
+    Boundary<TF>::process_inflow(input, input_nc);
 
     // add variables to the statistics
     if (stats.get_switch())

--- a/src/fields.cxx
+++ b/src/fields.cxx
@@ -1322,6 +1322,7 @@ std::string Fields<TF>::simplify_unit(const std::string str1, const std::string 
 
     //Loop through units to find matches; in which case add the powers
     int unit1_size = unit1.size();
+
     for (auto& u2 : unit2)
     {
         int i;
@@ -1332,7 +1333,7 @@ std::string Fields<TF>::simplify_unit(const std::string str1, const std::string 
                 if (u2.first == "kg") //Special case: there could be a kg/kg here to simplify
                 {
                     int j;
-                    for (j = i++ ; j < unit1_size; j++)
+                    for (j = i+1 ; j < unit1_size; j++)
                     {
                         if (u2.first == unit1[j].first)
                             break;

--- a/src/stats.cxx
+++ b/src/stats.cxx
@@ -269,7 +269,7 @@ namespace
             const int icells, const int ijcells)
     {
         #pragma omp parallel for
-        for (int k=kstart-1; k<kend+1; ++k)
+        for (int k=kstart; k<kend; ++k)
         {
             if (nmask[k])
             {
@@ -1385,7 +1385,7 @@ void Stats<TF>::calc_mask_mean_profile(
     // kend, so I send kcells-1 as the limit. This is not elegant, yet it works.
     calc_mean(
             prof.data(), fld.fld.data(), mfield.data(), flag, nmask,
-            gd.istart, gd.iend, gd.jstart, gd.jend, 0, gd.kcells-1, gd.icells, gd.ijcells);
+            gd.istart, gd.iend, gd.jstart, gd.jend, 1, gd.kcells, gd.icells, gd.ijcells);
 
     master.sum(prof.data(), gd.kcells);
 }
@@ -1412,7 +1412,7 @@ void Stats<TF>::calc_mask_stats(
                 mfield.data(), flag, nmask,
                 gd.istart, gd.iend,
                 gd.jstart, gd.jend,
-                gd.kstart, gd.kend,
+                gd.kstart, gd.kend + fld.loc[2],
                 gd.icells, gd.ijcells);
 
         master.sum(m.second.profs.at(varname).data.data(), gd.kcells);
@@ -1465,7 +1465,7 @@ void Stats<TF>::calc_mask_stats(
                 mfield.data(), flag, nmask,
                 gd.istart, gd.iend,
                 gd.jstart, gd.jend,
-                gd.kstart, gd.kend,
+                gd.kstart, gd.kend + w_loc,
                 gd.icells, gd.ijcells);
 
         master.sum(w_prime->fld_mean.data(), gd.kcells);
@@ -1499,7 +1499,7 @@ void Stats<TF>::calc_mask_stats(
                 mfield.data(), flag, nmask,
                 gd.istart, gd.iend,
                 gd.jstart, gd.jend,
-                gd.kstart, gd.kend,
+                gd.kstart, gd.kend + (1 - fld.loc[2]),
                 gd.icells, gd.ijcells);
 
         master.sum(m.second.profs.at(name).data.data(), gd.kcells);
@@ -1525,7 +1525,7 @@ void Stats<TF>::calc_mask_stats(
                 mfield.data(), flag, nmask,
                 gd.istart, gd.iend,
                 gd.jstart, gd.jend,
-                gd.kstart, gd.kend,
+                gd.kstart, gd.kend + (1 - fld.loc[2]),
                 gd.icells, gd.ijcells);
 
         master.sum(m.second.profs.at(name).data.data(), gd.kcells);
@@ -1687,7 +1687,7 @@ void Stats<TF>::calc_stats_mean(
                     mfield.data(), flag, nmask,
                     gd.istart, gd.iend,
                     gd.jstart, gd.jend,
-                    gd.kstart, gd.kend,
+                    gd.kstart, gd.kend + fld.loc[2],
                     gd.icells, gd.ijcells);
             master.sum(m.second.profs.at(varname).data.data(), gd.kcells);
 
@@ -1871,7 +1871,7 @@ void Stats<TF>::calc_stats_w(
                     flag, nmask,
                     gd.istart, gd.iend,
                     gd.jstart, gd.jend,
-                    gd.kstart, gd.kend,
+                    gd.kstart, gd.kend+1,
                     gd.icells, gd.ijcells);
             master.sum(fld_prime->fld_mean.data(), gd.kcells);
 
@@ -1896,7 +1896,7 @@ void Stats<TF>::calc_stats_w(
                     mfield.data(), flag, nmask,
                     gd.istart, gd.iend,
                     gd.jstart, gd.jend,
-                    gd.kstart, gd.kend+1,
+                    gd.kstart, gd.kend + w_loc,
                     gd.icells, gd.ijcells);
 
             master.sum(w_prime->fld_mean.data(), gd.kcells);
@@ -1907,7 +1907,7 @@ void Stats<TF>::calc_stats_w(
                     w_prime->fld_mean.data(),
                     gd.istart, gd.iend,
                     gd.jstart, gd.jend,
-                    gd.kstart, gd.kend+1,
+                    gd.kstart, gd.kend + w_loc,
                     gd.icells, gd.ijcells);
 
             fld_prime->loc = gd.wloc;
@@ -1923,7 +1923,7 @@ void Stats<TF>::calc_stats_w(
                     mfield.data(), flag, nmask,
                     gd.istart, gd.iend,
                     gd.jstart, gd.jend,
-                    gd.kstart, gd.kend,
+                    gd.kstart, gd.kend + w_loc,
                     gd.icells, gd.ijcells);
 
             master.sum(m.second.profs.at(name).data.data(), gd.kcells);
@@ -1964,7 +1964,7 @@ void Stats<TF>::calc_stats_diff(
                     mfield.data(), flag, nmask,
                     gd.istart, gd.iend,
                     gd.jstart, gd.jend,
-                    gd.kstart, gd.kend,
+                    gd.kstart, gd.kend+(1-fld.loc[2]),
                     gd.icells, gd.ijcells);
 
             master.sum(m.second.profs.at(name).data.data(), gd.kcells);
@@ -2182,7 +2182,7 @@ void Stats<TF>::calc_tend(Field3d<TF>& fld, const std::string& tend_name)
         {
             set_flag(flag, nmask, m.second, fld.loc[2]);
             calc_mean(m.second.profs.at(name).data.data(), fld.fld.data(), mfield.data(), flag, nmask,
-                    gd.istart, gd.iend, gd.jstart, gd.jend, gd.kstart, gd.kend, gd.icells, gd.ijcells);
+                    gd.istart, gd.iend, gd.jstart, gd.jend, gd.kstart, gd.kend+fld.loc[2], gd.icells, gd.ijcells);
             master.sum(m.second.profs.at(name).data.data(), gd.kcells);
 
             set_fillvalue_prof(m.second.profs.at(name).data.data(), nmask, gd.kstart, gd.kcells);


### PR DESCRIPTION
This is a first attempt at fixing the buffer overflow in the stats. I've put the bounds inside the calc_mean() function to kstart/kend, so that every caller has to decide on its own what the bounds are supposed to be.
At first glance (tested with RICO), this implementation does not seem to throw valgrind warnings, and I didn't see any NaNs in the netcdf file either. Better testing is still necessary, and help is appreciated.
 