### PR TITLE
Require lat lon

### DIFF
--- a/src/force.cxx
+++ b/src/force.cxx
@@ -346,6 +346,10 @@ Force<TF>::Force(Master& masterin, Grid<TF>& gridin, Fields<TF>& fieldsin, Input
     {
         swlspres = Large_scale_pressure_type::Geo_wind;
         fc = inputin.get_item<TF>("force", "fc", "", -1.);
+        // Test whether latitude is available in the input file.
+        if (fc < 0.)
+            inputin.get_item<TF>("grid", "lat", "");
+
         swtimedep_geo = inputin.get_item<bool>("force", "swtimedep_geo", "", false);
 
         tdep_geo.emplace("u_geo", new Timedep<TF>(master, grid, "u_geo", swtimedep_geo));

--- a/src/grid.cxx
+++ b/src/grid.cxx
@@ -61,8 +61,8 @@ Grid<TF>::Grid(Master& masterin, Input& input) :
     gd.utrans = input.get_item<TF>("grid", "utrans", "", 0.);
     gd.vtrans = input.get_item<TF>("grid", "vtrans", "", 0.);
 
-    gd.lat = input.get_item<TF>("grid", "lat", "",  0.); 
-    gd.lon = input.get_item<TF>("grid", "lon", "",  0.); 
+    gd.lat = input.get_item<TF>("grid", "lat", "",  -9999.);
+    gd.lon = input.get_item<TF>("grid", "lon", "",  -9999.);
 
     std::string swspatialorder = input.get_item<std::string>("grid", "swspatialorder", "");
 
@@ -217,8 +217,10 @@ void Grid<TF>::create_stats(Stats<TF>& stats)
     // Add variables to the statistics
     if (stats.get_switch())
     {
-        stats.add_time_series("lat", "Latitude", "degrees", group_name);
-        stats.add_time_series("lon", "Longitude", "degrees", group_name);
+        if (gd.lat>-1000.)
+            stats.add_time_series("lat", "Latitude", "degrees", group_name);
+        if (gd.lon>-1000.)
+            stats.add_time_series("lon", "Longitude", "degrees", group_name);
     }
 }
 
@@ -226,8 +228,10 @@ void Grid<TF>::create_stats(Stats<TF>& stats)
 template<typename TF>
 void Grid<TF>::exec_stats(Stats<TF>& stats)
 {
-    stats.set_time_series("lat", gd.lat);
-    stats.set_time_series("lon", gd.lon);
+    if (gd.lat>-1000.)
+        stats.set_time_series("lat", gd.lat);
+    if (gd.lon>-1000.)
+        stats.set_time_series("lon", gd.lon);
 }
 /**
  * This function calculates the scalars and arrays that contain the information

--- a/src/radiation_gcss.cxx
+++ b/src/radiation_gcss.cxx
@@ -317,6 +317,11 @@ Radiation_gcss<TF>::Radiation_gcss(Master& masterin, Grid<TF>& gridin, Fields<TF
     fr0 = inputin.get_item<TF>("radiation", "fr0", "");
     fr1 = inputin.get_item<TF>("radiation", "fr1", "");
     div = inputin.get_item<TF>("radiation", "div", "");
+    
+    //Test whether lat/lon exist in the input file
+    inputin.get_item<TF>("grid", "lat", "");
+    inputin.get_item<TF>("grid", "lon", "");
+
 }
 
 template<typename TF>

--- a/src/radiation_rrtmgp.cxx
+++ b/src/radiation_rrtmgp.cxx
@@ -695,6 +695,15 @@ Radiation_rrtmgp<TF>::Radiation_rrtmgp(
         const Float sza = inputin.get_item<Float>("radiation", "sza", "");
         mu0 = std::cos(sza);
     }
+    else
+    {
+        //Test whether lat/lon exist in the input file
+        if (sw_shortwave)
+        {
+            inputin.get_item<TF>("grid", "lat", "");
+            inputin.get_item<TF>("grid", "lon", "");
+        }
+    }
 
     // Surface diffuse radiation filtering
     sw_diffuse_filter = inputin.get_item<bool>("radiation", "swfilterdiffuse", "", false);

--- a/src/radiation_rrtmgp_rt.cu
+++ b/src/radiation_rrtmgp_rt.cu
@@ -2097,7 +2097,7 @@ void Radiation_rrtmgp_rt<TF>::exec(
                     const int year = timeloop.get_year();
                     const Float seconds_after_midnight = Float(timeloop.calc_hour_of_day()*3600);
                     std::tie(this->mu0, this->azimuth) = calc_cos_zenith_angle(
-                            lat, lon, day_of_year, seconds_after_midnight, year);
+                            gd.lat, gd.lon, day_of_year, seconds_after_midnight, year);
 
                     // Calculate correction factor for impact Sun's distance on the solar "constant"
                     const Float frac_day_of_year = Float(day_of_year) + seconds_after_midnight / Float(86400);

--- a/src/radiation_rrtmgp_rt.cxx
+++ b/src/radiation_rrtmgp_rt.cxx
@@ -530,8 +530,12 @@ Radiation_rrtmgp_rt<TF>::Radiation_rrtmgp_rt(
     }
     else
     {
-        lat = inputin.get_item<Float>("grid", "lat", "");
-        lon = inputin.get_item<Float>("grid", "lon", "");
+        //Test whether lat/lon exist in the input file
+        if (sw_shortwave)
+        {
+            inputin.get_item<TF>("grid", "lat", "");
+            inputin.get_item<TF>("grid", "lon", "");
+        }
     }
 
     gaslist = inputin.get_list<std::string>("radiation", "timedeplist_bg", "", std::vector<std::string>());


### PR DESCRIPTION
This commit makes lat/lon a requirement if it is necessary in force or radiation. It also leaves it out of stats if it is not given in the namelist.