### PR TITLE
Generic cmake cuda

### DIFF
--- a/config/generic.cmake
+++ b/config/generic.cmake
@@ -68,8 +68,8 @@ set(HDF5_LIB "hdf5")
 set(LIBS ${FFTW_LIB} ${FFTWF_LIB} ${NETCDF_LIB_C} ${HDF5_LIB}) #It may be necessary to add m z curl sz if necessary
 
 if(USECUDA)
-    set(CMAKE_CUDA_ARCHITECTURES 70)
-    set(USER_CUDA_NVCC_FLAGS "--expt-relaxed-constexpr")
+    set(CMAKE_CUDA_ARCHITECTURES "70;80;90")
+    set(USER_CUDA_NVCC_FLAGS "--expt-relaxed-constexpr -lineinfo")
     set(USER_CUDA_NVCC_FLAGS_RELEASE "-DNDEBUG")
     set(USER_CUDA_NVCC_FLAGS_DEBUG "-O0 -g -DCUDACHECKS")
     add_definitions(-DRTE_RRTMGP_GPU_MEMPOOL_CUDA)


### PR DESCRIPTION
Prerparing code for a wider range of GPUs in generic.cmake, so that it should run on most current GPUs out of the box.