### PR TITLE
Remove check on half levels in microhh_tools

### DIFF
--- a/python/3d_to_nc.py
+++ b/python/3d_to_nc.py
@@ -30,6 +30,7 @@ import numpy as np
 from multiprocessing import Pool
 
 def convert_to_nc(variables):
+    half_level_vars = ['w', 'lflx', 'sflx']
     
     for variable in variables:
         filename = "{0}.nc".format(variable)
@@ -42,7 +43,7 @@ def convert_to_nc(variables):
             dim['xh'] = dim.pop('x')
         if variable == 'v':
             dim['yh'] = dim.pop('y')
-        if variable == 'w':
+        if variable in half_level_vars:
             dim['zh'] = dim.pop('z')
         try:
             def convert(otime, tout):

--- a/python/microhh_tools.py
+++ b/python/microhh_tools.py
@@ -323,29 +323,6 @@ class Create_ncfile():
         else:
             precision = 'f8'
 
-        half_level_vars = [
-            'w',
-            'sw_flux_dn', 'sw_flux_dn_dir', 'sw_flux_up',
-            'sw_flux_dn_clear', 'sw_flux_dn_dir_clear', 'sw_flux_up_clear',
-            'lw_flux_dn', 'lw_flux_up'
-            'lw_flux_dn_clear', 'lw_flux_up_clear']
-
-        if(varname == 'u'):
-            try:
-                dimensions['xh'] = dimensions.pop('x')
-            except KeyError:
-                pass
-        if(varname == 'v'):
-            try:
-                dimensions['yh'] = dimensions.pop('y')
-            except KeyError:
-                pass
-        if(varname in half_level_vars):
-            try:
-                dimensions['zh'] = dimensions.pop('z')
-            except KeyError:
-                pass
-
         # create dimensions in netCDF file
         self.dim = {}
         self.dimvar = {}

--- a/src/radiation_gcss.cxx
+++ b/src/radiation_gcss.cxx
@@ -388,7 +388,7 @@ void Radiation_gcss<TF>::exec(
 template<typename TF>
 bool Radiation_gcss<TF>::check_field_exists(const std::string& name)
 {
-    if (name == "rflx" || name == "sflx")
+    if (name == "lflx" || name == "sflx")
         return true;
     else
         return false;


### PR DESCRIPTION
Such checks should happen in the caller functions. This already was fixed in cross through the addition of grid location in the filename; in dump/restart files this is now done with a (short) list of half level vars in 3d_to_nc