### PR TITLE
Flux stats bug

### DIFF
--- a/cases/drycblles/drycblles.ini
+++ b/cases/drycblles/drycblles.ini
@@ -3,9 +3,9 @@ npx=1
 npy=1
 
 [grid]
-itot=32
-jtot=32
-ktot=32
+itot=128
+jtot=128
+ktot=128
 
 xsize=3200.
 ysize=3200.

--- a/cases/drycblles/drycblles_stats.py
+++ b/cases/drycblles/drycblles_stats.py
@@ -38,4 +38,5 @@ for i, var in enumerate(vars):
 for i in range(2):
     axes[i,0].set_ylabel('z [m]')
 fig.tight_layout()
- 
+
+plt.show()

--- a/src/stats.cxx
+++ b/src/stats.cxx
@@ -1532,6 +1532,10 @@ void Stats<TF>::calc_stats_w(
         auto advec_flux = fields.get_tmp();
         auto fld_prime = fields.get_tmp();
         auto w_prime = fields.get_tmp();
+
+        w_prime->name = "w";
+        fld_prime->name = fld.name;
+
         for (auto& m : masks)
         {
             set_flag(flag, nmask, m.second, fld.loc[2]);
@@ -1570,7 +1574,6 @@ void Stats<TF>::calc_stats_w(
                     gd.jstart, gd.jend,
                     0, gd.kcells,
                     gd.icells, gd.ijcells);
-
             master.sum(w_prime->fld_mean.data(), gd.kcells);
 
             subtract_mean(
@@ -1583,6 +1586,7 @@ void Stats<TF>::calc_stats_w(
                     gd.icells, gd.ijcells);
 
             fld_prime->loc = fld.loc;
+
             advec.get_advec_flux(*advec_flux, *fld_prime, *w_prime);
 
             // Switch flag to flux location of `fld`.

--- a/src/stats.cxx
+++ b/src/stats.cxx
@@ -1543,7 +1543,7 @@ void Stats<TF>::calc_stats_w(
                     flag, nmask,
                     gd.istart, gd.iend,
                     gd.jstart, gd.jend,
-                    gd.kstart-1, gd.kend+1,
+                    0, gd.kcells,
                     gd.icells, gd.ijcells);
             master.sum(fld_prime->fld_mean.data(), gd.kcells);
 
@@ -1553,7 +1553,7 @@ void Stats<TF>::calc_stats_w(
                     fld_prime->fld_mean.data(),
                     gd.istart, gd.iend,
                     gd.jstart, gd.jend,
-                    gd.kstart-1, gd.kend+1,
+                    0, gd.kcells,
                     gd.icells, gd.ijcells);
 
 
@@ -1568,7 +1568,7 @@ void Stats<TF>::calc_stats_w(
                     mfield.data(), flag, nmask,
                     gd.istart, gd.iend,
                     gd.jstart, gd.jend,
-                    gd.kstart, gd.kend + w_loc,
+                    0, gd.kcells,
                     gd.icells, gd.ijcells);
 
             master.sum(w_prime->fld_mean.data(), gd.kcells);
@@ -1579,7 +1579,7 @@ void Stats<TF>::calc_stats_w(
                     w_prime->fld_mean.data(),
                     gd.istart, gd.iend,
                     gd.jstart, gd.jend,
-                    gd.kstart, gd.kend + w_loc,
+                    0, gd.kcells,
                     gd.icells, gd.ijcells);
 
             fld_prime->loc = fld.loc;
@@ -1595,7 +1595,7 @@ void Stats<TF>::calc_stats_w(
                     mfield.data(), flag, nmask,
                     gd.istart, gd.iend,
                     gd.jstart, gd.jend,
-                    gd.kstart, gd.kend + w_loc,
+                    0, gd.kcells,
                     gd.icells, gd.ijcells);
 
             master.sum(m.second.profs.at(name).data.data(), gd.kcells);

--- a/src/stats.cxx
+++ b/src/stats.cxx
@@ -1555,11 +1555,10 @@ void Stats<TF>::calc_stats_w(
                     fld_prime->fld.data(),
                     fld.fld.data(),
                     fld_prime->fld_mean.data(),
-                    gd.istart, gd.iend,
-                    gd.jstart, gd.jend,
+                    0, gd.icells,
+                    0, gd.jcells,
                     0, gd.kcells,
                     gd.icells, gd.ijcells);
-
 
             // Set flag for `w` level
             const int w_loc = 1;
@@ -1580,8 +1579,8 @@ void Stats<TF>::calc_stats_w(
                     w_prime->fld.data(),
                     fields.mp.at("w")->fld.data(),
                     w_prime->fld_mean.data(),
-                    gd.istart, gd.iend,
-                    gd.jstart, gd.jend,
+                    0, gd.icells,
+                    0, gd.jcells,
                     0, gd.kcells,
                     gd.icells, gd.ijcells);
 
@@ -1589,12 +1588,8 @@ void Stats<TF>::calc_stats_w(
 
             advec.get_advec_flux(*advec_flux, *fld_prime, *w_prime);
 
-            // Switch flag to flux location of `fld`.
-            // set_flag(flag, nmask, m.second, !fld.loc[2]);
-
             calc_mean(
                     m.second.profs.at(name).data.data(),
-                    // fld_prime->fld.data(),
                     advec_flux->fld.data(),
                     mfield.data(), flag, nmask,
                     gd.istart, gd.iend,


### PR DESCRIPTION
This is the first batch of fixes to the flux stats. This solves the Moser180 problem, but not the `2i5` flux problem. There is a wiggle in the profile near, which disappears if one resets the `fld_prime->fld_mean` to `0`. This suggests that there is a problem with the mean, which is hard to understand. I need help :).