### PR TITLE
Resolved wall LES working on CPU and GPU

### DIFF
--- a/include/diff_kernels.h
+++ b/include/diff_kernels.h
@@ -49,12 +49,12 @@ namespace Diff_kernels
             const int jj, const int kk)
     {
         const int ii = 1;
-        const int k_offset = (surface_model == Surface_model::Enabled) ? 1 : 0;
+        constexpr int k_offset = (surface_model == Surface_model::Enabled) ? 1 : 0;
 
         const TF zsl = z[kstart];
 
         // If the wall isn't resolved, calculate du/dz and dv/dz at lowest grid height using MO
-        if (surface_model == Surface_model::Enabled)
+        if constexpr (surface_model == Surface_model::Enabled)
         {
             for (int j=jstart; j<jend; ++j)
                 #pragma ivdep
@@ -165,7 +165,7 @@ namespace Diff_kernels
 
         const int ii = 1;
 
-        if (surface_model == Surface_model::Enabled)
+        if constexpr (surface_model == Surface_model::Enabled)
         {
             // bottom boundary
             for (int j=jstart; j<jend; ++j)
@@ -268,7 +268,7 @@ namespace Diff_kernels
 
         const int ii = 1;
 
-        if (surface_model == Surface_model::Enabled)
+        if constexpr (surface_model == Surface_model::Enabled)
         {
             // bottom boundary
             for (int j=jstart; j<jend; ++j)
@@ -413,7 +413,7 @@ namespace Diff_kernels
         const int ii = 1;
         const TF tPr_i = TF(1)/tPr;
 
-        if (surface_model == Surface_model::Enabled)
+        if constexpr (surface_model == Surface_model::Enabled)
         {
             // bottom boundary
             for (int j=jstart; j<jend; ++j)

--- a/include/diff_smag2_kl_kernels.cuh
+++ b/include/diff_smag2_kl_kernels.cuh
@@ -56,7 +56,7 @@ namespace diff_smag2
             const int ij  = i + j*jj;
             const int ijk = i + j*jj + k*kk;
 
-            if (surface_model_enabled)
+            if constexpr (surface_model_enabled)
             {
                 TF RitPrratio;
 

--- a/src/diff_smag2.cxx
+++ b/src/diff_smag2.cxx
@@ -479,7 +479,7 @@ void Diff_smag2<TF>::exec_viscosity(Stats<TF>&, Thermo<TF>& thermo)
             const TF* const restrict dudz,
             const TF* const restrict dvdz)
     {
-        dk::calc_strain2<TF, Surface_model::Enabled>(
+        dk::calc_strain2<TF, surface_model>(
                 fields.sd.at("evisc")->fld.data(),
                 fields.mp.at("u")->fld.data(),
                 fields.mp.at("v")->fld.data(),
@@ -505,7 +505,7 @@ void Diff_smag2<TF>::exec_viscosity(Stats<TF>&, Thermo<TF>& thermo)
         strain2_wrapper.template operator()<Surface_model::Enabled>(dudz.data(), dvdz.data());
     }
     else
-        strain2_wrapper.template operator()<Surface_model::Enabled>(nullptr, nullptr);
+        strain2_wrapper.template operator()<Surface_model::Disabled>(nullptr, nullptr);
 
     // Start with retrieving the stability information
     if (thermo.get_switch() == Thermo_type::Disabled)

--- a/src/diff_smag2.cxx
+++ b/src/diff_smag2.cxx
@@ -73,7 +73,7 @@ namespace
         constexpr TF n_mason = TF(1.);
         constexpr TF A_vandriest = TF(26.);
 
-        if (surface_model == Surface_model::Disabled)
+        if constexpr (surface_model == Surface_model::Disabled)
         {
             for (int k=kstart; k<kend; ++k)
             {

--- a/src/diff_tke2.cxx
+++ b/src/diff_tke2.cxx
@@ -505,7 +505,7 @@ Diff_tke2<TF>::Diff_tke2(
     const std::string group_name = "sgstke";
 
     // Set the switch between buoy/no buoy once
-    const std::string sw_thermo = inputin.get_item<std::string>("thermo", "swthermo", "");
+    const std::string sw_thermo = inputin.get_item<std::string>("thermo", "swthermo", "", "0");
     sw_buoy = (sw_thermo == "0") ? false : true;
 
     // Set the switch for use of Mason's wall correction


### PR DESCRIPTION
It seems that the error related to the wall-resolved LES has been solved, and was the result of one erroneous template parameter value in `diff_smag2.cxx`. I have a working Moser180 on CPU and GPU.

Also I have marked all if statements depending on `surface_model` as `constexpr` to ensure compile time evaluation.