### PR TITLE
Update to work with the latest version of the raytracing + ensure only lists of strings are saved in the namelist 

### DIFF
--- a/python/microhh_tools.py
+++ b/python/microhh_tools.py
@@ -152,6 +152,8 @@ class Read_namelist:
                 f.write('[{}]\n'.format(group))
                 for variable, value in self.groups[group].items():
                     if isinstance(value, list):
+                        if not isinstance(value[0], str):
+                            value = [str(v) for v in value]
                         value = ','.join(value)
                     elif isinstance(value, bool):
                         value = '1' if value else '0'


### PR DESCRIPTION
in cabauw_rt.ini.base, under [cross], xy is given for multiple levels. This is read as a list of integers, which causes line 155 of 'microhh_tools.py'  to crash when trying to save the namelist, because ','.join(list) does not work for a list of integers. Converting any list of non-strings to a list of strings fixes this problem