### PR TITLE
Don't `cudaFree` the `cuda_vector`'s.

### DIFF
--- a/src/boundary_surface_bulk.cu
+++ b/src/boundary_surface_bulk.cu
@@ -197,14 +197,6 @@ void Boundary_surface_bulk<TF>::clear_device(Thermo<TF>& thermo)
 {
     cuda_safe_call(cudaFree(obuk_g ));
     cuda_safe_call(cudaFree(ustar_g));
-
-    cuda_safe_call(cudaFree(z0m_g));
-
-    cuda_safe_call(cudaFree(dudz_mo_g));
-    cuda_safe_call(cudaFree(dvdz_mo_g));
-
-    if (thermo.get_switch() != Thermo_type::Disabled)
-        cuda_safe_call(cudaFree(dbdz_mo_g));
 }
 
 #ifdef USECUDA


### PR DESCRIPTION
`boundary_surface_bulk` tried to `cudaFree` some `cuda_vector`'s, which caused RICO on the GPU to fail.