### PR TITLE
upgrade script to make raytracer input

### DIFF
--- a/python/microhh_to_raytracer_input.py
+++ b/python/microhh_to_raytracer_input.py
@@ -30,6 +30,7 @@ Required input:
 - <name>.ini
 - <name>_input.nc
 - <name>.default.0000000.nc
+- grid.0000000
 - T.<time> (binary 3D field of absolute temperature)
 - qt.<time> (binary 3D field of specific humidity)
 
@@ -96,7 +97,6 @@ def calc_sun_distance_factor(day_of_year, seconds_since_midnight):
     # Based on: An Introduction to Atmospheric Radiation, Liou, Eq. 2.2.9.
     an = [1.000110, 0.034221, 0.000719]
     bn = [0,        0.001280, 0.000077]
-    day_of_year = 228.3
     frac_doy = day_of_year + seconds_since_midnight / 86400.
     t = 2. * np.pi*(frac_doy - 1.)/ 365.
 
@@ -112,14 +112,47 @@ def read_if_exists(var, t, dims):
     except:
         return np.zeros(dims)
 
+# functions to compute the relative humidity
+Rd = 287.04
+Rv = 461.5
+ep = Rd/Rv
+T0 = 273.15
+
+def esat_liq(T):
+    x = np.maximum(-75., T-T0)
+    return 611.21*np.exp(17.502*x / (240.97+x))
+
+def esat_ice(T):
+    x = np.maximum(-100., T-T0)
+    return 611.15*np.exp(22.452*x / (272.55+x))
+
+def qsat_liq(p, T):
+    return ep*esat_liq(T)/(p-(1.-ep)*esat_liq(T))
+
+def qsat_ice(p, T):
+    return ep*esat_ice(T)/(p-(1.-ep)*esat_ice(T))
+
+def water_fraction(T):
+    return np.maximum(0., np.minimum((T - 233.15) / (T0 - 233.15), 1.))
+
+def qsat(p, T):
+    alpha = water_fraction(T)
+    return alpha*qsat_liq(p, T) + (1.-alpha)*qsat_ice(p, T)
+
+
 parser = argparse.ArgumentParser()
 parser.add_argument("-n","--name", type=str, help="simulating name, that is, name of the .ini file")
 parser.add_argument("-t","--time", type=int, help="simulation time step to convert")
 parser.add_argument("-p","--path", type=str, help="Path to simulation files, defaults to current directory",default="./")
 args = parser.parse_args()
 
+# Save in single precision by default
+float_type = np.float32
+
 # some constants
-ep = 0.622
+xm_air = 28.97
+xm_h2o = 18.01528
+eps = xm_h2o / xm_air
 TF = np.float32
 g = 9.81
 
@@ -168,12 +201,23 @@ plev = nc_stat['thermo']['phydroh'][t_idx]
 rho = nc_stat['thermo']['rho'][t_idx]
 
 ### Read data
+# switches
+swtimedep = nl['radiation']['swupdatecolumn'] if 'swupdatecolumn' in nl['radiation'] else 0
+gaslist = nl['radiation']['timedeplist_gas'] if 'timedeplist_gas' in nl['radiation'] else []
+if 'aerosol' in nl.groups:
+    swaerosol = nl['aerosol']['swaerosol'] if 'swaerosol' in nl['aerosol'] else 0
+    swtimedep_aerosol = nl['aerosol']['swtimedep'] if 'swtimedep' in nl['aerosol'] else 0
+else:
+    swaerosol = 0
+    swtimedep_aerosol = 0
+
 # dimensions and grid
 itot = nl['grid']['itot']
 jtot = nl['grid']['jtot']
 ktot = nl['grid']['ktot']
 dims = (ktot, jtot, itot)
-grid = mht.Read_grid(itot, jtot, ktot, path+"grid.0000000")
+order = nl['grid']['swspatialorder']
+grid = mht.Read_grid(itot, jtot, ktot, order, path+"grid.0000000")
 dz = np.diff(grid.dim['zh'][:])
 
 zlay = grid.dim['z']
@@ -185,6 +229,7 @@ tlay = np.fromfile(path+"T.{:07d}".format(iotime),TF).reshape(dims)
 
 # convert qt from kg/kg to vmr
 h2o = qt / (ep - ep*qt)
+h2o = np.maximum(0, h2o)
 
 # cloud properties and effective radius
 ql = read_if_exists(path+"ql", iotime, dims)
@@ -193,7 +238,8 @@ lwp = ql * (dz*rho)[:,np.newaxis,np.newaxis] # kg/m2
 qi = read_if_exists(path+"qi", iotime, dims)
 iwp = qi * (dz*rho)[:,np.newaxis,np.newaxis] # kg/m2
 
-ftpnr_w = (4./3) * np.pi * 100e6 * 1e3
+nc0 = nl['micro']['Nc0']
+ftpnr_w = (4./3) * np.pi * nc0 * 1e3
 ftpnr_i = (4./3) * np.pi * 1e5 * 7e2
 sig_fac = np.exp(np.log(1.34)*np.log(1.34))
 rel = np.where(lwp>0, 1e6 * sig_fac * (lwp / dz[:,np.newaxis,np.newaxis] / ftpnr_w)**(1./3), 0)
@@ -209,18 +255,31 @@ nz = ktot
 grid_z = grid.dim['z']
 grid_zh = grid.dim['zh']
 
-# ozone profile
-o3 = nc_inp['init']['o3']
-
 # read bg profile
-h2o_bg = nc_inp['radiation']['h2o']
-o3_bg = nc_inp['radiation']['o3']
-zlay_bg = nc_inp['radiation']['z_lay']
-zlev_bg = nc_inp['radiation']['z_lev']
-play_bg = nc_inp['radiation']['p_lay']
-plev_bg = nc_inp['radiation']['p_lev']
-tlay_bg = nc_inp['radiation']['t_lay']
-tlev_bg = nc_inp['radiation']['t_lev']
+if swtimedep:
+    f_h2o_bg = interp1d(nc_inp['timedep']['time_ls'], nc_inp['timedep']['h2o_bg'], axis=0)
+    h2o_bg = f_h2o_bg(time)
+    f_zlay_bg = interp1d(nc_inp['timedep']['time_ls'], nc_inp['timedep']['z_lay'], axis=0)
+    zlay_bg = f_zlay_bg(time)
+    f_zlev_bg = interp1d(nc_inp['timedep']['time_ls'], nc_inp['timedep']['z_lev'], axis=0)
+    zlev_bg = f_zlev_bg(time)
+    f_play_bg = interp1d(nc_inp['timedep']['time_ls'], nc_inp['timedep']['p_lay'], axis=0)
+    play_bg = f_play_bg(time)
+    f_plev_bg = interp1d(nc_inp['timedep']['time_ls'], nc_inp['timedep']['p_lev'], axis=0)
+    plev_bg = f_plev_bg(time)
+    f_tlay_bg = interp1d(nc_inp['timedep']['time_ls'], nc_inp['timedep']['t_lay'], axis=0)
+    tlay_bg = f_tlay_bg(time)
+    f_tlev_bg = interp1d(nc_inp['timedep']['time_ls'], nc_inp['timedep']['t_lev'], axis=0)
+    tlev_bg = f_tlev_bg(time)
+else:
+    h2o_bg = nc_inp['radiation']['h2o']
+    zlay_bg = nc_inp['radiation']['z_lay']
+    zlev_bg = nc_inp['radiation']['z_lev']
+    play_bg = nc_inp['radiation']['p_lay']
+    plev_bg = nc_inp['radiation']['p_lev']
+    tlay_bg = nc_inp['radiation']['t_lay']
+    tlev_bg = nc_inp['radiation']['t_lev']
+
 
 # find lowest height in bg profile that is heigher than domain top
 z_tod = grid.dim['zh'][-1]
@@ -251,104 +310,153 @@ nc_out.createDimension("yh", jtot+1)
 nc_out.createDimension("zh", nz+1)
 
 # write raytracing grids
-nc_x = nc_out.createVariable("x", "f8", ("x",))
+nc_x = nc_out.createVariable("x", float_type, ("x",))
 nc_x[:] = grid.dim['x'][:]
-nc_y = nc_out.createVariable("y", "f8", ("y",))
+nc_y = nc_out.createVariable("y", float_type, ("y",))
 nc_y[:] = grid.dim['y'][:]
-nc_z = nc_out.createVariable("z", "f8", ("z",))
+nc_z = nc_out.createVariable("z", float_type, ("z",))
 nc_z[:] = grid_z
 
 grid_xh = np.append(grid.dim['xh'][:], grid.dim['xh'][-1] +  (grid.dim['xh'][1] -  grid.dim['xh'][0]))
 grid_yh = np.append(grid.dim['yh'][:], grid.dim['yh'][-1] +  (grid.dim['yh'][1] -  grid.dim['yh'][0]))
 
-nc_xh = nc_out.createVariable("xh", "f8", ("xh",))
+nc_xh = nc_out.createVariable("xh", float_type, ("xh",))
 nc_xh[:] = grid_xh
-nc_yh = nc_out.createVariable("yh", "f8", ("yh",))
+nc_yh = nc_out.createVariable("yh", float_type, ("yh",))
 nc_yh[:] = grid_yh
-nc_zh = nc_out.createVariable("zh", "f8", ("zh",))
+nc_zh = nc_out.createVariable("zh", float_type, ("zh",))
 nc_zh[:] = grid_zh
 
-nc_zlay = nc_out.createVariable("zlay", "f8", ("lay"))
-nc_zlev = nc_out.createVariable("z_lev", "f8", ("lev"))
+nc_zlay = nc_out.createVariable("zlay", float_type, ("lay"))
+nc_zlev = nc_out.createVariable("z_lev", float_type, ("lev"))
 nc_zlay[:] = zlay
 nc_zlev[:] = zlev
 
 # write pressures
-nc_play = nc_out.createVariable("p_lay", "f8", ("lay","y","x"))
+nc_play = nc_out.createVariable("p_lay", float_type, ("lay","y","x"))
 nc_play[:] = np.tile(play.reshape(len(play),1,1), (1, jtot, itot))
-nc_plev = nc_out.createVariable("p_lev", "f8", ("lev","y","x"))
+nc_plev = nc_out.createVariable("p_lev", float_type, ("lev","y","x"))
 nc_plev[:] = np.tile(plev.reshape(len(plev),1,1), (1, jtot, itot))
 
 # write density profile
-nc_rho = nc_out.createVariable("rho", "f8", ("z",))
+nc_rho = nc_out.createVariable("rho", float_type, ("z",))
 nc_rho[:] = rho
 
-# write ozone
-nc_o3 = nc_out.createVariable("vmr_o3", "f8", ("lay","y","x"))
-nc_o3[:] = np.tile(np.append(o3[:], o3_bg[zmin_idx:])[:,None,None], (1, jtot, itot))
-
 # remaining 3D variables
-nc_h2o = nc_out.createVariable("vmr_h2o", "f8", ("lay","y","x"))
+nc_h2o = nc_out.createVariable("vmr_h2o", float_type, ("lay","y","x"))
 nc_h2o[:] = np.append(h2o[:], np.tile(h2o_bg[zmin_idx:][:,None,None], (1, jtot, itot)), axis=0)
-nc_tlay = nc_out.createVariable("t_lay", "f8", ("lay","y","x"))
+nc_tlay = nc_out.createVariable("t_lay", float_type, ("lay","y","x"))
 nc_tlay[:] = np.append(tlay[:], np.tile(tlay_bg[zmin_idx:][:,None,None], (1, jtot, itot)), axis=0)
 
 # We do not bother about t_lev yet  because the ray tracer is shortwave-only, but we do need to supply it in the netcdf
-nc_tlev = nc_out.createVariable("t_lev", "f8", ("lev","y","x"))
+nc_tlev = nc_out.createVariable("t_lev", float_type, ("lev","y","x"))
 nc_tlev[:] = 0 
 
 # Liquid water path
-nc_lwp = nc_out.createVariable("lwp" , "f8", ("lay","y","x"))
+nc_lwp = nc_out.createVariable("lwp" , float_type, ("lay","y","x"))
 nc_lwp[:] = 0
 nc_lwp[:ktot] = lwp
 
 # Liquid water effective radius
-nc_rel = nc_out.createVariable("rel" , "f8", ("lay","y","x"))
+nc_rel = nc_out.createVariable("rel" , float_type, ("lay","y","x"))
 nc_rel[:] = 0
 nc_rel[:ktot] = rel
 
 # Ice water path
-nc_iwp = nc_out.createVariable("iwp" , "f8", ("lay","y","x"))
+nc_iwp = nc_out.createVariable("iwp" , float_type, ("lay","y","x"))
 nc_iwp[:] = 0
 nc_iwp[:ktot] = iwp
 
 # Ice effective radius
-nc_rei = nc_out.createVariable("rei" , "f8", ("lay","y","x"))
+nc_rei = nc_out.createVariable("rei" , float_type, ("lay","y","x"))
 nc_rei[:] = 0
 nc_rei[:ktot] = rei
 
 # surface properties
-nc_alb_dir = nc_out.createVariable("sfc_alb_dir", "f8", ("y","x","band_sw"))
+nc_alb_dir = nc_out.createVariable("sfc_alb_dir", float_type, ("y","x","band_sw"))
 nc_alb_dir[:] = nl['radiation']['sfc_alb_dir']
-nc_alb_dif = nc_out.createVariable("sfc_alb_dif", "f8", ("y","x","band_sw"))
+nc_alb_dif = nc_out.createVariable("sfc_alb_dif", float_type, ("y","x","band_sw"))
 nc_alb_dif[:] = nl['radiation']['sfc_alb_dif']
-nc_emis = nc_out.createVariable("emis_sfc", "f8", ("y","x","band_lw"))
+nc_emis = nc_out.createVariable("emis_sfc", float_type, ("y","x","band_lw"))
 nc_emis[:] = nl['radiation']['emis_sfc']
-nc_tsfc = nc_out.createVariable("t_sfc", "f8", ("y","x"))
+nc_tsfc = nc_out.createVariable("t_sfc", float_type, ("y","x"))
 nc_tsfc[:] = 0 # don't bother about longwave for now
 
 # solar angles
-nc_mu = nc_out.createVariable("mu0", "f8", ("y","x"))
+nc_mu = nc_out.createVariable("mu0", float_type, ("y","x"))
 nc_mu[:] = mu0
-nc_az = nc_out.createVariable("azi", "f8", ("y","x"))
+nc_az = nc_out.createVariable("azi", float_type, ("y","x"))
 nc_az[:] = azi
 
 # Scaling top-of-atmosphere irradiance
-nc_ts = nc_out.createVariable("tsi_scaling", "f8")
+nc_ts = nc_out.createVariable("tsi_scaling", float_type)
 nc_ts[:] = tsi_scaling
 
-# trace gases:
-for var in nc_inp['radiation'].variables:
-    if len(nc_inp['radiation'][var].dimensions) == 0:
-        nc_gas = nc_out.createVariable("vmr_"+var, "f8")
-        nc_gas[:] = nc_inp['radiation'][var][:]
+# add gasses
+possible_gases = ["co2", "o3", "n2o", "co", "ch4", "o2", "n2", "ccl4", "cfc11", "cfc12", "cfc22",
+                  "hfc143a", "hfc125", "hfc23", "hfc32", "hfc134a", "cf4", "no2"]
+for gas in possible_gases:
+    if gas in nc_inp['radiation'].variables.keys():
+        if len(nc_inp['radiation'][gas].dimensions) != 0 and len(nc_inp['init'][gas].dimensions) != 0:
+            # in the domain
+            if gas in gaslist:
+                f_gas = interp1d(nc_inp['timedep']['time_ls'], nc_inp['timedep'][gas], axis=0)
+                gas_prof = f_gas(time)
+            else:
+                gas_prof = nc_inp['init'][gas]
+            # above the domain
+            if gas in gaslist and swtimedep:
+                f_gas_bg = interp1d(nc_inp['timedep']['time_ls'], nc_inp['timedep'][gas + '_bg'], axis=0)
+                gas_bg = f_gas_bg(time)
+            else:
+                gas_bg = nc_inp['radiation'][gas]
+
+            nc_out.createVariable("vmr_" + gas, float_type, ("lay", "y", "x"))
+            nc_out["vmr_" + gas][:] = np.tile(np.append(gas_prof[:], gas_bg[zmin_idx:])[:, None, None], (1, jtot, itot))
+
+        elif len(nc_inp['radiation'][gas].dimensions) == 0 and len(nc_inp['init'][gas].dimensions) == 0:
+            nc_out.createVariable("vmr_" + gas, float_type)
+            nc_out["vmr_" + gas][:] = nc_inp['radiation'][gas][:]
+
+        else:
+            print("not supported input for gas: " + gas)
+
+# add aerosols + relative humidity
+if swaerosol:
+    aerosol_species = ["aermr01", "aermr02", "aermr03", "aermr04", "aermr05", "aermr06",
+                         "aermr07", "aermr08", "aermr09", "aermr10", "aermr11"]
+
+    # aerosol mixing ratios
+    for aerosol in aerosol_species:
+        # in the domain
+        if swtimedep_aerosol:
+            f_aermr = interp1d(nc_inp['timedep']['time_aerosols'], nc_inp['timedep'][aerosol], axis=0)
+            aermr = np.maximum(f_aermr(time), 0)
+        else:
+            aermr = nc_inp['init'][aerosol]
+        # above the domain
+        if swtimedep_aerosol and swtimedep:
+            f_aermr_bg = interp1d(nc_inp['timedep']['time_aerosols'], nc_inp['timedep'][aerosol + '_bg'], axis=0)
+            aermr_bg = np.maximum(f_aermr_bg(time), 0)
+        else:
+            aermr_bg = nc_inp['radiation'][aerosol]
+
+        nc_out.createVariable(aerosol, float_type, ("lay", "y", "x"))
+        nc_out[aerosol][:] = np.tile(np.append(aermr[:], aermr_bg[zmin_idx:])[:, None, None], (1, jtot, itot))
+
+    # relative humidity
+    q = nc_h2o[:] * eps / (1 + nc_h2o[:] * eps)
+    qs = qsat(nc_play[:, :, :], nc_tlay[:])
+    rh = np.maximum(np.minimum(q / qs, 1), 0)
+    nc_out.createVariable("rh", float_type, ("lay", "y", "x"))
+    nc_out['rh'][:] = rh
 
 # size of null-collision grid
-nc_ng_x = nc_out.createVariable("ngrid_x", "f8")
+nc_ng_x = nc_out.createVariable("ngrid_x", float_type)
 nc_ng_x[:] = ng_x
-nc_ng_y = nc_out.createVariable("ngrid_y", "f8")
+nc_ng_y = nc_out.createVariable("ngrid_y", float_type)
 nc_ng_y[:] = ng_y
-nc_ng_z = nc_out.createVariable("ngrid_z", "f8")
+nc_ng_z = nc_out.createVariable("ngrid_z", float_type)
 nc_ng_z[:] = ng_z
 
 nc_out.close()


### PR DESCRIPTION
I updated the microhh_to_raytracer_input script (in consultation with @MennoVeerman), such that it can now also be used for simulations with aerosols and time dependent background profiles. In addition, the standard is now single precision, the fixed day-of-year is removed and a small change was needed for the script to work with the latest version of the microhh_tools. 