### PR TITLE
Aerosol/background naming changes + update `cabauw` case.

### DIFF
--- a/cases/cabauw/cabauw.ini.base
+++ b/cases/cabauw/cabauw.ini.base
@@ -54,7 +54,7 @@ sfc_alb_dif=0.22
 swclearskystats=1
 swfixedsza=0
 swtimedep_background=None
-timedeplist_gas=None
+#timedeplist_gas=None
 
 [aerosol]
 swaerosol=None

--- a/cases/cabauw/cabauw.ini.base
+++ b/cases/cabauw/cabauw.ini.base
@@ -2,8 +2,8 @@
 # `cabauw_input.py` sets all `None` values, and writes the final `cabauw.ini` input file.
 
 [master]
-npx=1
-npy=1
+npx=None
+npy=None
 wallclocklimit=1e9
 
 [grid]
@@ -128,7 +128,7 @@ savetime=3600
 outputiter=20
 adaptivestep=true
 rkorder=4
-datetime_utc=2016-08-15 06:00:00
+datetime_utc=None
 
 [stats]
 swstats=1

--- a/cases/cabauw/cabauw.ini.base
+++ b/cases/cabauw/cabauw.ini.base
@@ -39,6 +39,7 @@ swtimedep_pbot=1
 swmicro=2mom_warm
 cflmax=1.2
 Nc0=200000000
+Ni0=1e5
 
 [radiation]
 swradiation=None
@@ -52,9 +53,12 @@ sfc_alb_dir=0.22
 sfc_alb_dif=0.22
 swclearskystats=1
 swfixedsza=0
+swupdatecolumn=None
+timedeplist_gas=None
 
 [aerosol]
-swaerosol=1
+swaerosol=None
+swtimedep=None
 
 [boundary]
 swboundary=None

--- a/cases/cabauw/cabauw.ini.base
+++ b/cases/cabauw/cabauw.ini.base
@@ -53,7 +53,7 @@ sfc_alb_dir=0.22
 sfc_alb_dif=0.22
 swclearskystats=1
 swfixedsza=0
-swupdatecolumn=None
+swtimedep_background=None
 timedeplist_gas=None
 
 [aerosol]

--- a/cases/cabauw/cabauw_input.py
+++ b/cases/cabauw/cabauw_input.py
@@ -52,8 +52,9 @@ def create_case_input(
         use_rrtmgp,
         use_rt,
         use_aerosols,
-        use_tdep_background,
         use_tdep_aerosols,
+        use_tdep_gasses,
+        use_tdep_background,
         use_homogeneous_z0,
         use_homogeneous_ls,
         gpt_set,
@@ -101,16 +102,16 @@ def create_case_input(
     # Subtract start time.
     ls2d_z['time_sec'] = ls2d_z['time_sec'] - ls2d_z['time_sec'][0]
 
-    if use_aerosols:
-        cams = xr.open_dataset('cams_20160815.nc')
-        check_time_bounds(cams, start_date, end_date)
+    # Read CAMS for aerosols and gasses other than ozone.
+    cams = xr.open_dataset('cams_20160815.nc')
+    check_time_bounds(cams, start_date, end_date)
 
-        # Remove top level CAMS to stay within RRTMGP pressure bounds.
-        cams = cams.sel(lay=slice(0, 135))
+    # Remove top level CAMS to stay within RRTMGP pressure bounds.
+    cams = cams.sel(lay=slice(0, 135))
 
-        # Interpolate to LES levels and ERA5 time (CAMS is 3-hourly).
-        cams = cams.interp(time=ls2d.time)
-        cams_z = cams.interp(z=z)
+    # Interpolate to LES levels and ERA5 time (CAMS is 3-hourly).
+    cams = cams.interp(time=ls2d.time)
+    cams_z = cams.interp(z=z)
 
     if not use_rrtmgp:
         # Read ERA5 radiation, de-accumulate, and interpolate to LS2D times.
@@ -174,8 +175,8 @@ def create_case_input(
         ini['radiation']['swtimedep_prescribed'] = True
 
     ini['radiation']['swtimedep_background'] = use_tdep_background
-    if use_tdep_background:
-        ini['radiation']['timedeplist_gas'] = 'o3'
+    if use_tdep_gasses:
+        ini['radiation']['timedeplist_gas'] = ['o3', 'co2', 'ch4']
 
     ini['aerosol']['swaerosol'] = use_aerosols
     ini['aerosol']['swtimedep'] = use_tdep_aerosols
@@ -270,11 +271,11 @@ def create_case_input(
         h2o = qt_mean / (eps - eps * qt_mean)
         add_nc_var('h2o', ('z'), nc_init, h2o)
         add_nc_var('o3',  ('z'), nc_init, ls2d_z.o3[0,:]*1e-6)
+        add_nc_var('co2', ('z'), nc_init, cams_z.co2[0,:]*1e-6)
+        add_nc_var('ch4', ('z'), nc_init, cams_z.ch4[0,:]*1e-6)
 
         # Constant concentrations:
         for group in (nc_init, nc_rad):
-            add_nc_var('co2', None, group, 397e-6)
-            add_nc_var('ch4', None, group, 1.8315e-6)
             add_nc_var('n2o', None, group, 3.2699e-7)
             add_nc_var('n2',  None, group, 0.781)
             add_nc_var('o2',  None, group, 0.209)
@@ -286,16 +287,23 @@ def create_case_input(
         add_nc_var('p_lev', ('lev'), nc_rad, ls2d_z.p_lev.mean(axis=0))
         add_nc_var('t_lay', ('lay'), nc_rad, ls2d_z.t_lay.mean(axis=0))
         add_nc_var('t_lev', ('lev'), nc_rad, ls2d_z.t_lev.mean(axis=0))
-        add_nc_var('o3',    ('lay'), nc_rad, ls2d_z.o3_lay.mean(axis=0)*1e-6)
         add_nc_var('h2o',   ('lay'), nc_rad, ls2d_z.h2o_lay.mean(axis=0))
+        add_nc_var('o3',    ('lay'), nc_rad, ls2d_z.o3_lay.mean(axis=0)*1e-6)
+        add_nc_var('co2',   ('lay'), nc_rad, cams_z.co2_lay.mean(axis=0))
+        add_nc_var('ch4',   ('lay'), nc_rad, cams_z.ch4_lay.mean(axis=0))
 
-        if use_tdep_background or use_tdep_aerosols:
+        if use_tdep_background or use_tdep_aerosols or use_tdep_gasses:
             # NOTE: bit cheap, but ERA and CAMS are at the same time period/interval here.
             add_nc_dim('time_rad', ls2d_z.dims['time'], nc_tdep)
             add_nc_var('time_rad', ('time_rad'), nc_tdep, ls2d_z.time_sec)
 
             add_nc_dim('lay', ls2d_z.dims['lay'], nc_tdep)
             add_nc_dim('lev', ls2d_z.dims['lev'], nc_tdep)
+
+        if use_tdep_gasses:
+            add_nc_var('o3',  ('time_rad', 'z'), nc_tdep, ls2d_z.o3*1e-6)
+            add_nc_var('co2', ('time_rad', 'z'), nc_tdep, cams_z.co2)
+            add_nc_var('ch4', ('time_rad', 'z'), nc_tdep, cams_z.ch4)
 
         # Time dependent background profiles T, h2o, o3, ...
         if use_tdep_background:
@@ -307,7 +315,8 @@ def create_case_input(
             add_nc_var('t_lev',  ('time_rad', 'lev'), nc_tdep, ls2d_z.t_lev)
             add_nc_var('h2o_bg', ('time_rad', 'lay'), nc_tdep, ls2d_z.h2o_lay)
             add_nc_var('o3_bg',  ('time_rad', 'lay'), nc_tdep, ls2d_z.o3_lay*1e-6)
-            add_nc_var('o3',     ('time_rad', 'z'),   nc_tdep, ls2d_z.o3*1e-6)
+            add_nc_var('co2_bg', ('time_rad', 'lay'), nc_tdep, cams_z.co2_lay)
+            add_nc_var('ch4_bg', ('time_rad', 'lay'), nc_tdep, cams_z.ch4_lay)
 
         # Aerosols for domain and background column
         if use_aerosols:
@@ -471,8 +480,15 @@ if __name__ == '__main__':
     use_homogeneous_z0 = True    # False = checkerboard pattern roughness lengths.
     use_homogeneous_ls = True    # False = checkerboard pattern (some...) land-surface fields.
     use_aerosols = False         # False = no aerosols in RRTMGP.
-    use_tdep_background = False  # False = time fixed RRTMGP T/h2o/o3 background profiles.
     use_tdep_aerosols = False    # False = time fixed RRTMGP aerosol in domain and background.
+    use_tdep_gasses = False      # False = time fixed ERA5 (o3) and CAMS (co2, ch4) gasses.
+    use_tdep_background = False  # False = time fixed RRTMGP T/h2o/o3 background profiles.
+
+    """
+    NOTE: `use_tdep_aerosols` and `use_tdep_gasses` specify whether the aerosols and gasses
+          used by RRTMGP are updated inside the LES domain. If `use_tdep_background` is true, the
+          aerosols, gasses, and the temperature & humidity are also updated on the RRTMGP background levels.
+    """
 
     # Switch between the two default RRTMGP g-point sets.
     gpt_set = '128_112' # or '256_224'
@@ -500,8 +516,9 @@ if __name__ == '__main__':
             use_rrtmgp,
             use_rt,
             use_aerosols,
-            use_tdep_background,
             use_tdep_aerosols,
+            use_tdep_gasses,
+            use_tdep_background,
             use_homogeneous_z0,
             use_homogeneous_ls,
             gpt_set,

--- a/cases/cabauw/cabauw_input.py
+++ b/cases/cabauw/cabauw_input.py
@@ -173,7 +173,7 @@ def create_case_input(
         ini['radiation']['swradiation'] = 'prescribed'
         ini['radiation']['swtimedep_prescribed'] = True
 
-    ini['radiation']['swupdatecolumn'] = use_tdep_background
+    ini['radiation']['swtimedep_background'] = use_tdep_background
     if use_tdep_background:
         ini['radiation']['timedeplist_gas'] = 'o3'
 
@@ -471,8 +471,8 @@ if __name__ == '__main__':
     use_homogeneous_z0 = True    # False = checkerboard pattern roughness lengths.
     use_homogeneous_ls = True    # False = checkerboard pattern (some...) land-surface fields.
     use_aerosols = False         # False = no aerosols in RRTMGP.
-    use_tdep_background = False  # False = time fixed RRTMGP T + h2o + o3 background profiles.
-    use_tdep_aerosols = False    # False = time fixed RRTMGP aerosol background profiles.
+    use_tdep_background = False  # False = time fixed RRTMGP T/h2o/o3 background profiles.
+    use_tdep_aerosols = False    # False = time fixed RRTMGP aerosol in domain and background.
 
     # Switch between the two default RRTMGP g-point sets.
     gpt_set = '128_112' # or '256_224'

--- a/include/background_profs.h
+++ b/include/background_profs.h
@@ -71,9 +71,11 @@ private:
     Fields<TF>& fields;
 
     // Case switches
-    bool sw_update_background;
     bool sw_aerosol;
-    bool sw_aerosol_timedep;
+
+    bool swtimedep_background;
+    bool swtimedep_aerosol;
+
     double dt_rad;
     unsigned long idt_rad;
 

--- a/include/radiation_rrtmgp.h
+++ b/include/radiation_rrtmgp.h
@@ -206,11 +206,12 @@ class Radiation_rrtmgp : public Radiation<TF>
         bool sw_shortwave;
         bool sw_clear_sky_stats;
         bool sw_fixed_sza;
-        bool sw_update_background;
         bool sw_aerosol;
-        bool sw_aerosol_timedep;
         bool sw_delta_cloud;
         bool sw_delta_aer;
+
+        bool swtimedep_background;
+        bool swtimedep_aerosol;
 
         bool sw_homogenize_sfc_sw;
         bool sw_homogenize_sfc_lw;

--- a/include/radiation_rrtmgp_rt.h
+++ b/include/radiation_rrtmgp_rt.h
@@ -220,12 +220,13 @@ class Radiation_rrtmgp_rt : public Radiation<TF>
         bool sw_shortwave;
         bool sw_clear_sky_stats;
         bool sw_fixed_sza;
-        bool sw_update_background;
         bool sw_aerosol;
-        bool sw_aerosol_timedep;
         bool sw_delta_cloud;
         bool sw_delta_aer;
         bool sw_2str_when_no_clouds;
+
+        bool swtimedep_background;
+        bool swtimedep_aerosol;
 
         bool sw_homogenize_sfc_sw;
         bool sw_homogenize_sfc_lw;

--- a/src/aerosol.cxx
+++ b/src/aerosol.cxx
@@ -88,7 +88,7 @@ void Aerosol<TF>::create(Input& inputin, Netcdf_handle& input_nc, Stats<TF>& sta
     {
         // create time dependent profiles
         const TF offset = 0;
-        std::string timedep_dim = "time_aerosols";
+        std::string timedep_dim = "time_rad";
 
         tdep_aermr01 = std::make_unique<Timedep<TF>>(master, grid, "aermr01", sw_timedep);
         tdep_aermr01->create_timedep_prof(input_nc, offset, timedep_dim);

--- a/src/background_profs.cxx
+++ b/src/background_profs.cxx
@@ -133,28 +133,27 @@ void Background<TF>::create(Input& inputin, Netcdf_handle& input_nc, Stats<TF>& 
 
     // create time dependent profiles
     const TF offset = 0;
-    std::string timedep_dim_ls = "time_ls";
+    std::string timedep_dim = "time_rad";
 
     // temperature, pressure and moisture
     tdep_t_lay = std::make_unique<Timedep<TF>>(master, grid, "t_lay", sw_update_background);
-    tdep_t_lay->create_timedep_prof(input_nc, offset, timedep_dim_ls, n_lay);
+    tdep_t_lay->create_timedep_prof(input_nc, offset, timedep_dim, n_lay);
     tdep_t_lev = std::make_unique<Timedep<TF>>(master, grid, "t_lev", sw_update_background);
-    tdep_t_lev->create_timedep_prof(input_nc, offset, timedep_dim_ls, n_lev);
+    tdep_t_lev->create_timedep_prof(input_nc, offset, timedep_dim, n_lev);
     tdep_p_lay = std::make_unique<Timedep<TF>>(master, grid, "p_lay", sw_update_background);
-    tdep_p_lay->create_timedep_prof(input_nc, offset, timedep_dim_ls, n_lay);
+    tdep_p_lay->create_timedep_prof(input_nc, offset, timedep_dim, n_lay);
     tdep_p_lev = std::make_unique<Timedep<TF>>(master, grid, "p_lev", sw_update_background);
-    tdep_p_lev->create_timedep_prof(input_nc, offset, timedep_dim_ls, n_lev);
+    tdep_p_lev->create_timedep_prof(input_nc, offset, timedep_dim, n_lev);
     tdep_h2o = std::make_unique<Timedep<TF>>(master, grid, "h2o_bg", sw_update_background);
-    tdep_h2o->create_timedep_prof(input_nc, offset, timedep_dim_ls, n_lay);
+    tdep_h2o->create_timedep_prof(input_nc, offset, timedep_dim, n_lay);
 
     // gasses
     for (auto& it : tdep_gases)
-        it.second->create_timedep_prof(input_nc, offset, timedep_dim_ls, n_lay);
+        it.second->create_timedep_prof(input_nc, offset, timedep_dim, n_lay);
 
     //aerosols
     if (sw_aerosol && sw_aerosol_timedep)
     {
-        std::string timedep_dim = "time_aerosols";
         tdep_aermr01 = std::make_unique<Timedep<TF>>(master, grid, "aermr01_bg", sw_update_background);
         tdep_aermr01->create_timedep_prof(input_nc, offset, timedep_dim, n_lay);
         tdep_aermr02 = std::make_unique<Timedep<TF>>(master, grid, "aermr02_bg", sw_update_background);

--- a/src/background_profs.cxx
+++ b/src/background_profs.cxx
@@ -44,13 +44,13 @@ Background<TF>::Background(
         master(masterin), grid(gridin), fields(fieldsin)
 {
     // Read `.ini` settings.
-    sw_update_background = inputin.get_item<bool>("radiation", "swupdatecolumn", "", false);
+    swtimedep_background = inputin.get_item<bool>("radiation", "swtimedep_background", "", false);
 
-    if (!sw_update_background)
+    if (!swtimedep_background)
         return;
 
     sw_aerosol = inputin.get_item<bool>("aerosol", "swaerosol", "", false);
-    sw_aerosol_timedep = inputin.get_item<bool>("aerosol", "swtimedep", "", false);
+    swtimedep_aerosol = inputin.get_item<bool>("aerosol", "swtimedep", "", false);
     dt_rad = inputin.get_item<double>("radiation", "dt_rad", "");
     gaslist = inputin.get_list<std::string>("radiation", "timedeplist_gas", "", std::vector<std::string>());
 
@@ -64,7 +64,7 @@ Background<TF>::Background(
     {
         if (std::find(possible_gases.begin(), possible_gases.end(), it) != possible_gases.end())
         {
-            tdep_gases.emplace(it, new Timedep<TF>(master, grid, it+"_bg", sw_update_background));
+            tdep_gases.emplace(it, new Timedep<TF>(master, grid, it+"_bg", swtimedep_background));
         }
         else
         {
@@ -95,7 +95,7 @@ void Background<TF>::init(Netcdf_handle& input_nc)
             n_lev = rad_nc.get_dimension_size("lev");
     }
 
-    if (!sw_update_background)
+    if (!swtimedep_background)
         return;
 
     idt_rad = convert_to_itime(dt_rad);
@@ -128,7 +128,7 @@ template <typename TF>
 void Background<TF>::create(Input& inputin, Netcdf_handle& input_nc, Stats<TF>& stats)
 {
     // Read input from NetCDF and prepare statistics output.
-    if (!sw_update_background)
+    if (!swtimedep_background)
         return;
 
     // create time dependent profiles
@@ -136,15 +136,15 @@ void Background<TF>::create(Input& inputin, Netcdf_handle& input_nc, Stats<TF>& 
     std::string timedep_dim = "time_rad";
 
     // temperature, pressure and moisture
-    tdep_t_lay = std::make_unique<Timedep<TF>>(master, grid, "t_lay", sw_update_background);
+    tdep_t_lay = std::make_unique<Timedep<TF>>(master, grid, "t_lay", swtimedep_background);
     tdep_t_lay->create_timedep_prof(input_nc, offset, timedep_dim, n_lay);
-    tdep_t_lev = std::make_unique<Timedep<TF>>(master, grid, "t_lev", sw_update_background);
+    tdep_t_lev = std::make_unique<Timedep<TF>>(master, grid, "t_lev", swtimedep_background);
     tdep_t_lev->create_timedep_prof(input_nc, offset, timedep_dim, n_lev);
-    tdep_p_lay = std::make_unique<Timedep<TF>>(master, grid, "p_lay", sw_update_background);
+    tdep_p_lay = std::make_unique<Timedep<TF>>(master, grid, "p_lay", swtimedep_background);
     tdep_p_lay->create_timedep_prof(input_nc, offset, timedep_dim, n_lay);
-    tdep_p_lev = std::make_unique<Timedep<TF>>(master, grid, "p_lev", sw_update_background);
+    tdep_p_lev = std::make_unique<Timedep<TF>>(master, grid, "p_lev", swtimedep_background);
     tdep_p_lev->create_timedep_prof(input_nc, offset, timedep_dim, n_lev);
-    tdep_h2o = std::make_unique<Timedep<TF>>(master, grid, "h2o_bg", sw_update_background);
+    tdep_h2o = std::make_unique<Timedep<TF>>(master, grid, "h2o_bg", swtimedep_background);
     tdep_h2o->create_timedep_prof(input_nc, offset, timedep_dim, n_lay);
 
     // gasses
@@ -152,29 +152,29 @@ void Background<TF>::create(Input& inputin, Netcdf_handle& input_nc, Stats<TF>& 
         it.second->create_timedep_prof(input_nc, offset, timedep_dim, n_lay);
 
     //aerosols
-    if (sw_aerosol && sw_aerosol_timedep)
+    if (sw_aerosol && swtimedep_aerosol)
     {
-        tdep_aermr01 = std::make_unique<Timedep<TF>>(master, grid, "aermr01_bg", sw_update_background);
+        tdep_aermr01 = std::make_unique<Timedep<TF>>(master, grid, "aermr01_bg", swtimedep_background);
         tdep_aermr01->create_timedep_prof(input_nc, offset, timedep_dim, n_lay);
-        tdep_aermr02 = std::make_unique<Timedep<TF>>(master, grid, "aermr02_bg", sw_update_background);
+        tdep_aermr02 = std::make_unique<Timedep<TF>>(master, grid, "aermr02_bg", swtimedep_background);
         tdep_aermr02->create_timedep_prof(input_nc, offset, timedep_dim, n_lay);
-        tdep_aermr03 = std::make_unique<Timedep<TF>>(master, grid, "aermr03_bg", sw_update_background);
+        tdep_aermr03 = std::make_unique<Timedep<TF>>(master, grid, "aermr03_bg", swtimedep_background);
         tdep_aermr03->create_timedep_prof(input_nc, offset, timedep_dim, n_lay);
-        tdep_aermr04 = std::make_unique<Timedep<TF>>(master, grid, "aermr04_bg", sw_update_background);
+        tdep_aermr04 = std::make_unique<Timedep<TF>>(master, grid, "aermr04_bg", swtimedep_background);
         tdep_aermr04->create_timedep_prof(input_nc, offset, timedep_dim, n_lay);
-        tdep_aermr05 = std::make_unique<Timedep<TF>>(master, grid, "aermr05_bg", sw_update_background);
+        tdep_aermr05 = std::make_unique<Timedep<TF>>(master, grid, "aermr05_bg", swtimedep_background);
         tdep_aermr05->create_timedep_prof(input_nc, offset, timedep_dim, n_lay);
-        tdep_aermr06 = std::make_unique<Timedep<TF>>(master, grid, "aermr06_bg", sw_update_background);
+        tdep_aermr06 = std::make_unique<Timedep<TF>>(master, grid, "aermr06_bg", swtimedep_background);
         tdep_aermr06->create_timedep_prof(input_nc, offset, timedep_dim, n_lay);
-        tdep_aermr07 = std::make_unique<Timedep<TF>>(master, grid, "aermr07_bg", sw_update_background);
+        tdep_aermr07 = std::make_unique<Timedep<TF>>(master, grid, "aermr07_bg", swtimedep_background);
         tdep_aermr07->create_timedep_prof(input_nc, offset, timedep_dim, n_lay);
-        tdep_aermr08 = std::make_unique<Timedep<TF>>(master, grid, "aermr08_bg", sw_update_background);
+        tdep_aermr08 = std::make_unique<Timedep<TF>>(master, grid, "aermr08_bg", swtimedep_background);
         tdep_aermr08->create_timedep_prof(input_nc, offset, timedep_dim, n_lay);
-        tdep_aermr09 = std::make_unique<Timedep<TF>>(master, grid, "aermr09_bg", sw_update_background);
+        tdep_aermr09 = std::make_unique<Timedep<TF>>(master, grid, "aermr09_bg", swtimedep_background);
         tdep_aermr09->create_timedep_prof(input_nc, offset, timedep_dim, n_lay);
-        tdep_aermr10 = std::make_unique<Timedep<TF>>(master, grid, "aermr10_bg", sw_update_background);
+        tdep_aermr10 = std::make_unique<Timedep<TF>>(master, grid, "aermr10_bg", swtimedep_background);
         tdep_aermr10->create_timedep_prof(input_nc, offset, timedep_dim, n_lay);
-        tdep_aermr11 = std::make_unique<Timedep<TF>>(master, grid, "aermr11_bg", sw_update_background);
+        tdep_aermr11 = std::make_unique<Timedep<TF>>(master, grid, "aermr11_bg", swtimedep_background);
         tdep_aermr11->create_timedep_prof(input_nc, offset, timedep_dim, n_lay);
     }
 
@@ -195,7 +195,7 @@ void Background<TF>::create(Input& inputin, Netcdf_handle& input_nc, Stats<TF>& 
         stats.add_prof("o3_bg", "o3", "kg Kg-1", "lay", group_name);
 
     // aerosols
-    if (sw_aerosol && sw_aerosol_timedep)
+    if (sw_aerosol && swtimedep_aerosol)
     {
         stats.add_prof("aermr01_bg", "Sea salt (0.03 - 0.5 um) mixing ratio", "kg Kg-1", "lay", group_name);
         stats.add_prof("aermr02_bg", "Sea salt (0.5 - 5 um) mixing ratio", "kg Kg-1", "lay", group_name);
@@ -214,7 +214,7 @@ void Background<TF>::create(Input& inputin, Netcdf_handle& input_nc, Stats<TF>& 
 template <typename TF>
 void Background<TF>::update_time_dependent(Timeloop<TF>& timeloop)
 {
-    if (!sw_update_background)
+    if (!swtimedep_background)
         return;
 
     const bool do_radiation = ((timeloop.get_itime() % idt_rad == 0) && !timeloop.in_substep()) ;
@@ -233,7 +233,7 @@ void Background<TF>::update_time_dependent(Timeloop<TF>& timeloop)
             it.second->update_time_dependent_prof(gasprofs.at(it.first), timeloop, n_lay);
 
         // aerosols
-        if (sw_aerosol && sw_aerosol_timedep)
+        if (sw_aerosol && swtimedep_aerosol)
         {
             tdep_aermr01 ->update_time_dependent_prof(aermr01, timeloop, n_lay);
             tdep_aermr02 ->update_time_dependent_prof(aermr02, timeloop, n_lay);
@@ -254,7 +254,7 @@ void Background<TF>::update_time_dependent(Timeloop<TF>& timeloop)
 template<typename TF>
 void Background<TF>::exec_stats(Stats<TF>& stats)
 {
-    if (!sw_update_background)
+    if (!swtimedep_background)
         return;
 
     auto& gd = grid.get_grid_data();
@@ -271,7 +271,7 @@ void Background<TF>::exec_stats(Stats<TF>& stats)
         stats.set_prof_background("o3_bg", gasprofs.at("o3"));
 
     //aerosols
-    if (sw_aerosol && sw_aerosol_timedep)
+    if (sw_aerosol && swtimedep_aerosol)
     {
         stats.set_prof_background("aermr01_bg", aermr01);
         stats.set_prof_background("aermr02_bg", aermr02);

--- a/src/radiation_rrtmgp.cxx
+++ b/src/radiation_rrtmgp.cxx
@@ -662,11 +662,12 @@ Radiation_rrtmgp<TF>::Radiation_rrtmgp(
     sw_longwave  = inputin.get_item<bool>("radiation", "swlongwave" , "", true);
     sw_shortwave = inputin.get_item<bool>("radiation", "swshortwave", "", true);
     sw_fixed_sza = inputin.get_item<bool>("radiation", "swfixedsza", "", true);
-    sw_update_background = inputin.get_item<bool>("radiation", "swupdatecolumn", "", false);
     sw_aerosol = inputin.get_item<bool>("aerosol", "swaerosol", "", false);
-    sw_aerosol_timedep = inputin.get_item<bool>("aerosol", "swtimedep", "", false);
     sw_delta_cloud = inputin.get_item<bool>("radiation", "swdeltacloud", "", false);
     sw_delta_aer = inputin.get_item<bool>("radiation", "swdeltaaer", "", false);
+
+    swtimedep_background = inputin.get_item<bool>("radiation", "swtimedep_background", "", false);
+    swtimedep_aerosol = inputin.get_item<bool>("aerosol", "swtimedep", "", false);
 
     sw_clear_sky_stats = inputin.get_item<bool>("radiation", "swclearskystats", "", false);
     sw_homogenize_sfc_sw = inputin.get_item<bool>("radiation", "swhomogenizesfc_sw", "", false);
@@ -1206,7 +1207,7 @@ void Radiation_rrtmgp<TF>::create_column(
                 "Pa", "lev", root_group,
                 p_lev.v());
 
-        if (sw_update_background || !sw_fixed_sza)
+        if (swtimedep_background || !sw_fixed_sza)
         {
             stats.add_prof("sw_flux_up_ref",
                            "Shortwave upwelling flux of reference column",
@@ -1218,7 +1219,7 @@ void Radiation_rrtmgp<TF>::create_column(
                            "Shortwave direct downwelling flux of reference column",
                            "W m-2", "lev", group_name);
         }
-        if (sw_update_background)
+        if (swtimedep_background)
         {
             stats.add_prof("lw_flux_up_ref",
                            "Longwave upwelling flux of reference column",
@@ -1310,7 +1311,7 @@ void Radiation_rrtmgp<TF>::create_column_longwave(
             n_lay_col);
 
     // Save the reference profile fluxes in the stats.
-    if (stats.get_switch() && !sw_update_background)
+    if (stats.get_switch() && !swtimedep_background)
     {
         const std::string group_name = "radiation";
 
@@ -1386,7 +1387,7 @@ void Radiation_rrtmgp<TF>::create_column_shortwave(
         // Save the reference profile fluxes in the stats.
         if (stats.get_switch())
         {
-            if (!sw_update_background)
+            if (!swtimedep_background)
             {
                 const std::string group_name = "radiation";
 
@@ -1679,12 +1680,12 @@ void Radiation_rrtmgp<TF>::exec(
         const bool compute_clouds = true;
 
         // get aerosol mixing ratios
-        if (sw_aerosol && sw_aerosol_timedep)
+        if (sw_aerosol && swtimedep_aerosol)
             aerosol.get_radiation_fields(aerosol_concs);
 
         try
         {
-            if (sw_update_background)
+            if (swtimedep_background)
             {
                 // Temperature, pressure and moisture
                 background.get_tpm(t_lay_col, t_lev_col, p_lay_col, p_lev_col, gas_concs_col);
@@ -1692,7 +1693,7 @@ void Radiation_rrtmgp<TF>::exec(
                 // gasses
                 background.get_gasses(gas_concs_col);
                 // aerosols
-                if (sw_aerosol && sw_aerosol_timedep)
+                if (sw_aerosol && swtimedep_aerosol)
                 {
                     background.get_aerosols(aerosol_concs_col);
                 }
@@ -1700,7 +1701,7 @@ void Radiation_rrtmgp<TF>::exec(
 
             if (sw_longwave)
             {
-                if (sw_update_background)
+                if (swtimedep_background)
                 {
                     // Calculate new background column for the longwave.
                     const TF p_top = thermo.get_basestate_vector("ph")[gd.kend];
@@ -1771,7 +1772,7 @@ void Radiation_rrtmgp<TF>::exec(
                     set_sun_location(timeloop);
                 }
 
-                if (!sw_fixed_sza || sw_update_background)
+                if (!sw_fixed_sza || swtimedep_background)
                 {
                 // Calculate new background column for the shortwave.
                     if (is_day(this->mu0))
@@ -1989,7 +1990,7 @@ void Radiation_rrtmgp<TF>::exec_all_stats(
                 save_stats_and_cross(*fields.sd.at("lw_flux_dn_clear"), "lw_flux_dn_clear", gd.wloc);
             }
 
-            if (sw_update_background)
+            if (swtimedep_background)
             {
                 stats.set_prof_background("lw_flux_up_ref", lw_flux_up_col.v());
                 stats.set_prof_background("lw_flux_dn_ref", lw_flux_dn_col.v());
@@ -2028,7 +2029,7 @@ void Radiation_rrtmgp<TF>::exec_all_stats(
                 Float mean_aod = total_aod/ncol;
                 stats.set_time_series("AOD550", mean_aod);
             }
-            if (sw_update_background || !sw_fixed_sza)
+            if (swtimedep_background || !sw_fixed_sza)
             {
                 stats.set_prof_background("sw_flux_up_ref", sw_flux_up_col.v());
                 stats.set_prof_background("sw_flux_dn_ref", sw_flux_dn_col.v());
@@ -2141,7 +2142,7 @@ void Radiation_rrtmgp<TF>::exec_individual_column_stats(
 
     try
     {
-        if (sw_update_background)
+        if (swtimedep_background)
         {
             // Temperature and pressure
             background.get_tpm(t_lay_col, t_lev_col, p_lay_col, p_lev_col,  gas_concs_col);
@@ -2149,7 +2150,7 @@ void Radiation_rrtmgp<TF>::exec_individual_column_stats(
             // gasses
             background.get_gasses(gas_concs_col);
             // aerosols
-            if (sw_aerosol && sw_aerosol_timedep)
+            if (sw_aerosol && swtimedep_aerosol)
             {
                 background.get_aerosols(aerosol_concs_col);
             }
@@ -2158,7 +2159,7 @@ void Radiation_rrtmgp<TF>::exec_individual_column_stats(
         // Calculate long wave radiation.
         if (sw_longwave)
         {
-            if (sw_update_background)
+            if (swtimedep_background)
             {
                 // Calculate new background column for the longwave.
                 const TF p_top = thermo.get_basestate_vector("ph")[gd.kend];
@@ -2196,7 +2197,7 @@ void Radiation_rrtmgp<TF>::exec_individual_column_stats(
                 set_sun_location(timeloop);
             }
 
-            if (!sw_fixed_sza || sw_update_background)
+            if (!sw_fixed_sza || swtimedep_background)
             {
                 // Calculate new background column for the shortwave.
                 if (is_day(this->mu0))

--- a/src/radiation_rrtmgp.cxx
+++ b/src/radiation_rrtmgp.cxx
@@ -826,10 +826,10 @@ void Radiation_rrtmgp<TF>::create(
     // Setup timedependent gasses
     auto& gd = grid.get_grid_data();
     const TF offset = 0;
-    std::string timedep_dim_ls = "time_ls";
+    std::string timedep_dim = "time_rad";
 
     for (auto& it : tdep_gases)
-        it.second->create_timedep_prof(input_nc, offset, timedep_dim_ls, gd.ktot);
+        it.second->create_timedep_prof(input_nc, offset, timedep_dim, gd.ktot);
 
     // Initialize the tendency if the radiation is used.
     if (stats.get_switch() && (sw_longwave || sw_shortwave))

--- a/src/radiation_rrtmgp_rt.cxx
+++ b/src/radiation_rrtmgp_rt.cxx
@@ -647,10 +647,10 @@ void Radiation_rrtmgp_rt<TF>::create(
 
     // Setup timedependent gasses
     const TF offset = 0;
-    std::string timedep_dim_ls = "time_ls";
+    std::string timedep_dim = "time_rad";
 
     for (auto& it : tdep_gases)
-        it.second->create_timedep_prof(input_nc, offset, timedep_dim_ls, gd.ktot);
+        it.second->create_timedep_prof(input_nc, offset, timedep_dim, gd.ktot);
 
     // Initialize the tendency if the radiation is used.
     if (stats.get_switch() && (sw_longwave || sw_shortwave))

--- a/src/radiation_rrtmgp_rt.cxx
+++ b/src/radiation_rrtmgp_rt.cxx
@@ -493,14 +493,14 @@ Radiation_rrtmgp_rt<TF>::Radiation_rrtmgp_rt(
     sw_longwave      = inputin.get_item<bool>("radiation", "swlongwave" , "", true);
     sw_shortwave     = inputin.get_item<bool>("radiation", "swshortwave", "", true);
     sw_fixed_sza     = inputin.get_item<bool>("radiation", "swfixedsza", "", true);
-    sw_update_background = inputin.get_item<bool>("radiation", "swupdatecolumn", "", false);
     sw_aerosol      = inputin.get_item<bool>("aerosol", "swaerosol", "", false);
-    sw_aerosol_timedep = inputin.get_item<bool>("aerosol", "swtimedep", "", false);
     sw_delta_cloud   = inputin.get_item<bool>("radiation", "swdeltacloud", "", false);
     sw_delta_aer     = inputin.get_item<bool>("radiation", "swdeltaaer", "", false);
     sw_2str_when_no_clouds = inputin.get_item<bool>("radiation", "sw2strwhennoclouds", "", false);
-
     sw_clear_sky_stats = inputin.get_item<bool>("radiation", "swclearskystats", "", false);
+
+    swtimedep_background = inputin.get_item<bool>("radiation", "swtimedep_background", "", false);
+    swtimedep_aerosol = inputin.get_item<bool>("aerosol", "swtimedep", "", false);
 
     sw_homogenize_sfc_sw = inputin.get_item<bool>("radiation", "swhomogenizesfc_sw", "", false);
     sw_homogenize_sfc_lw = inputin.get_item<bool>("radiation", "swhomogenizesfc_lw", "", false);
@@ -997,7 +997,7 @@ void Radiation_rrtmgp_rt<TF>::create_column(
                 "Pa", "lev", root_group,
                 p_lev.v());
 
-        if (sw_update_background || !sw_fixed_sza)
+        if (swtimedep_background || !sw_fixed_sza)
         {
             stats.add_prof("sw_flux_up_ref",
                            "Shortwave upwelling flux of reference column",
@@ -1009,7 +1009,7 @@ void Radiation_rrtmgp_rt<TF>::create_column(
                            "Shortwave direct downwelling flux of reference column",
                            "W m-2", "lev", group_name);
         }
-        if (sw_update_background)
+        if (swtimedep_background)
         {
             stats.add_prof("lw_flux_up_ref",
                            "Longwave upwelling flux of reference column",
@@ -1102,7 +1102,7 @@ void Radiation_rrtmgp_rt<TF>::create_column_longwave(
             n_lay_col);
 
     // Save the reference profile fluxes in the stats.
-    if (stats.get_switch() && !sw_update_background)
+    if (stats.get_switch() && !swtimedep_background)
     {
         const std::string group_name = "radiation";
 
@@ -1179,7 +1179,7 @@ void Radiation_rrtmgp_rt<TF>::create_column_shortwave(
         // Save the reference profile fluxes in the stats.
         if (stats.get_switch())
         {
-            if (!sw_update_background)
+            if (!swtimedep_background)
             {
                 const std::string group_name = "radiation";
 


### PR DESCRIPTION
As discussed, some name changes in the code/ini file/Cabauw case:
- Renamed `swupdatecolumn` to `swtimedep_column`
- Put both the aerosol and T/h2o/... background at the same NetCDF `time_rad` dimension.

For testing, I added the option for time dependent background/aerosol profiles to the Cabauw case. In addition, I made the simulation period a bit more flexible, by explicitly setting the `start_date` and `end_date` in `cabauw_input.py`. As a test, I ran the case twice, once from 09-11 UTC, and once from 10-11 UTC. In both cases, the aerosol/background profiles are identical at 10 and 11 UTC:

![Figure_3](https://github.com/microhh/microhh/assets/1067637/3de1cb5b-91c9-42b1-8e18-a43d0cee3941)
![Figure_2](https://github.com/microhh/microhh/assets/1067637/50f9b233-7c81-4f63-a838-48794d7d60d0)
![Figure_1aer](https://github.com/microhh/microhh/assets/1067637/84915816-4b27-4c34-9f2d-a2a7f480a307)
