### PR TITLE
fix grid.0000000 read with new arg in microhh_tools.Read_grid

### DIFF
--- a/python/microhh_to_raytracer_input.py
+++ b/python/microhh_to_raytracer_input.py
@@ -24,7 +24,7 @@
 Convert MicroHH input and output to a netCDF input file for the standalone version of the ray tracer (see /rte-rrtmgp-cpp/src_test)
 
 How to use:
-run 'python microhh_to_raytracing_input.nc --name <simulation name> --time <time step to convert> --path <path to simulation files (defaults to "./")>'
+run 'python microhh_to_raytracing_input.py --name <simulation name> --time <time step to convert> --path <path to simulation files (defaults to "./")>'
 
 Required input:
 - <name>.ini
@@ -173,7 +173,7 @@ itot = nl['grid']['itot']
 jtot = nl['grid']['jtot']
 ktot = nl['grid']['ktot']
 dims = (ktot, jtot, itot)
-grid = mht.Read_grid(itot, jtot, ktot, path+"grid.0000000")
+grid = mht.Read_grid(itot, jtot, ktot,filename=path+"grid.0000000")
 dz = np.diff(grid.dim['zh'][:])
 
 zlay = grid.dim['z']


### PR DESCRIPTION
The updated version of `Read_grid` changes the keyword args, so the raytracer preprocessor passed the filename to the wrong argument. 

(and fixed a typo in the usage description)