### PR TITLE
Bugfix masked surface statistics.

### DIFF
--- a/src/fields.cxx
+++ b/src/fields.cxx
@@ -212,6 +212,7 @@ namespace
     void set_xy_mask(
             TF* const restrict mask,
             TF* const restrict maskh,
+            TF* const restrict mask_bot,
             const TF* const restrict xymask,
             const int istart, const int iend,
             const int jstart, const int jend,
@@ -237,6 +238,14 @@ namespace
                     const int ijk = ij + k*ijcells;
                     maskh[ijk] = xymask[ij] > TF(0.5) ? TF(1) : TF(0);
                 }
+
+        for (int j=jstart; j<jend; j++)
+            #pragma ivdep
+            for (int i=istart; i<iend; i++)
+            {
+                const int ij = i + j*icells;
+                mask_bot[ij] = xymask[ij] > TF(0.5) ? TF(1) : TF(0);
+            }
     }
 
     template<typename TF>
@@ -715,6 +724,7 @@ void Fields<TF>::get_mask(Stats<TF>& stats, std::string mask_name)
         set_xy_mask(
                 mask->fld.data(),
                 maskh->fld.data(),
+                maskh->fld_bot.data(),
                 xymasks.at(mask_name).data(),
                 gd.istart, gd.iend,
                 gd.jstart, gd.jend,

--- a/src/stats.cxx
+++ b/src/stats.cxx
@@ -287,11 +287,18 @@ namespace
         }
     }
 
+
     template<typename TF>
     void calc_mean_2d(
-            TF& out, const TF* const restrict fld,
-            const int istart, const int iend, const int jstart, const int jend,
-            const int icells, const int itot, const int jtot)
+            TF& out,
+            const TF* const restrict fld,
+            const unsigned int* const mask_bot,
+            const int nmask_bot,
+            const int flag,
+            const int istart, const int iend,
+            const int jstart, const int jend,
+            const int icells,
+            const int itot, const int jtot)
     {
         double tmp = 0.;
 
@@ -300,17 +307,19 @@ namespace
             for (int i=istart; i<iend; ++i)
             {
                 const int ij  = i + j*icells;
-                tmp += fld[ij];
+                tmp += in_mask<double>(mask_bot[ij], flag) * fld[ij];
             }
 
-        out = tmp / (itot*jtot);
+        out = tmp / nmask_bot;
     }
 
 
     template<typename TF>
     void calc_mean_projected_mask(
-            TF* const restrict prof, const TF* const restrict fld,
-            const unsigned int* const mask_bot, const int nmask_bot,
+            TF* const restrict prof,
+            const TF* const restrict fld,
+            const unsigned int* const mask_bot,
+            const int nmask_bot,
             const int flag,
             const int istart, const int iend,
             const int jstart, const int jend,
@@ -1324,15 +1333,28 @@ void Stats<TF>::set_mask_thres(
 
     if (mode == Stats_mask_type::Plus)
         calc_mask_thres<TF, Stats_mask_type::Plus>(
-                mfield.data(), mfield_bot.data(), flag, flagh,
-                fld.fld.data(), fldh.fld.data(), fldh.fld_bot.data(), threshold,
+                mfield.data(),
+                mfield_bot.data(),
+                flag,
+                flagh,
+                fld.fld.data(),
+                fldh.fld.data(),
+                fldh.fld_bot.data(),
+                threshold,
                 gd.istart, gd.jstart, gd.kstart,
                 gd.iend,   gd.jend,   gd.kend,
                 gd.icells, gd.ijcells, gd.kcells);
+
     else if (mode == Stats_mask_type::Min)
         calc_mask_thres<TF, Stats_mask_type::Min>(
-                mfield.data(), mfield_bot.data(), flag, flagh,
-                fld.fld.data(), fldh.fld.data(), fldh.fld_bot.data(), threshold,
+                mfield.data(),
+                mfield_bot.data(),
+                flag,
+                flagh,
+                fld.fld.data(),
+                fldh.fld.data(),
+                fldh.fld_bot.data(),
+                threshold,
                 gd.istart, gd.jstart, gd.kstart,
                 gd.iend,   gd.jend,   gd.kend,
                 gd.icells, gd.ijcells, gd.kcells);
@@ -1818,7 +1840,9 @@ void Stats<TF>::calc_tend(Field3d<TF>& fld, const std::string& tend_name)
 
 template<typename TF>
 void Stats<TF>::calc_stats_2d(
-        const std::string& varname, const std::vector<TF>& fld, const TF offset)
+        const std::string& varname,
+        const std::vector<TF>& fld,
+        const TF offset)
 {
     auto& gd = grid.get_grid_data();
 
@@ -1826,17 +1850,32 @@ void Stats<TF>::calc_stats_2d(
     {
         for (auto& m : masks)
         {
-            calc_mean_2d(m.second.tseries.at(varname).data, fld.data(),
-                    gd.istart, gd.iend, gd.jstart, gd.jend, gd.icells, gd.itot, gd.jtot);
-            master.sum(&m.second.tseries.at(varname).data, 1);
-            m.second.tseries.at(varname).data += offset;
+            if (m.second.nmask_bot > 0)
+            {
+                calc_mean_2d(
+                        m.second.tseries.at(varname).data,
+                        fld.data(),
+                        mfield_bot.data(),
+                        m.second.nmask_bot,
+                        m.second.flag,
+                        gd.istart, gd.iend,
+                        gd.jstart, gd.jend,
+                        gd.icells, gd.itot, gd.jtot);
+
+                master.sum(&m.second.tseries.at(varname).data, 1);
+                m.second.tseries.at(varname).data += offset;
+            }
+            else
+                m.second.tseries.at(varname).data = netcdf_fp_fillvalue<TF>();
         }
     }
 }
 
 template<typename TF>
 void Stats<TF>::calc_stats_soil(
-        const std::string varname, const std::vector<TF>& fld, const TF offset)
+        const std::string varname,
+        const std::vector<TF>& fld,
+        const TF offset)
 {
     /*
        Calculate soil statistics, using the surface mask
@@ -1852,8 +1891,10 @@ void Stats<TF>::calc_stats_soil(
             if (m.second.nmask_bot > 0)
             {
                 calc_mean_projected_mask(
-                        m.second.soil_profs.at(varname).data.data(), fld.data(),
-                        mfield_bot.data(), m.second.nmask_bot,
+                        m.second.soil_profs.at(varname).data.data(),
+                        fld.data(),
+                        mfield_bot.data(),
+                        m.second.nmask_bot,
                         m.second.flag,
                         agd.istart, agd.iend,
                         agd.jstart, agd.jend,


### PR DESCRIPTION
The surface mask was not applied to the 2D statistics. Fixes https://github.com/microhh/microhh/issues/258

Discussion point: the routine `calc_stats_2d()` is only used for surface fields, and as such, now uses the surface mask. Should we rename this function to e.g. `calc_stats_surface()`? In principle, you could throw a 2D xy slice from a 3D field in this function, but then the incorrect mask would be used.

Old results:
![Screenshot_20240925_124641](https://github.com/user-attachments/assets/6b0b081d-a614-42c2-98df-1853c527654c)

New results:
![Screenshot_20240925_141735](https://github.com/user-attachments/assets/c584b9d0-206e-4e50-a1b9-3fa1192316cd)
