### PR TITLE
Save thermo state before splitting off the thread to avoid overwrite and failing restarts

### DIFF
--- a/src/model.cxx
+++ b/src/model.cxx
@@ -526,11 +526,15 @@ void Model<TF>::exec()
                         #endif
 
                         // Save data to disk.
+
+                        // Save the thermo before the split of the thread, to avoid overwrite during stats
+                        // leading to restart failures.
+                        thermo->save(iotime);
+
                         #pragma omp task default(shared)
                         {
                             timeloop->save(iotime, itime, idt, iteration);
                             fields  ->save(iotime);
-                            thermo  ->save(iotime);
                             boundary->save(iotime, *thermo);
                         }
                     }


### PR DESCRIPTION
In the current code, the restart state is saved on a thread, to allow the model to continue. We did make a copy of the background state for stats, but did not solve the problem for a standard save. I did not like the copy solution for stats for the general code, because the copy is only made for the GPU. On the CPU it works because the threading is disabled. This solution does the save of thermo on the main thread.

With this fix we are good to go for 2.0!