### PR TITLE
Print cross/dump messages before actually triggering the functions.

### DIFF
--- a/src/model.cxx
+++ b/src/model.cxx
@@ -443,12 +443,6 @@ void Model<TF>::exec()
                     const int iotime = timeloop->get_iotime();
                     const double dt = timeloop->get_dt();
 
-                    // Write cross and dump messages here, as they don't have an `exec()` function...
-                    if (cross->do_cross(itime))
-                        master.print_message("Saving cross-sections for time %f\n", time);
-                    if (dump->do_dump(itime, idt))
-                        master.print_message("Saving field dumps for time %f\n", time);
-
                     // NOTE: `radiation->exec_all_stats()` needs to stay before `calculate_statistics()`...
                     if (column->do_column(itime) && !(stats->do_statistics(itime) || cross->do_cross(itime) || dump->do_dump(itime, idt)))
                     {
@@ -628,6 +622,8 @@ void Model<TF>::calculate_statistics(int iteration, double time, unsigned long i
     // Do the statistics.
     if (stats->do_statistics(itime))
     {
+        master.print_message("Saving statistics for time %f\n", time);
+
         // Calculate statistics
         if (!stats->do_tendency())
             calc_masks();
@@ -645,6 +641,8 @@ void Model<TF>::calculate_statistics(int iteration, double time, unsigned long i
     // Save the selected cross sections to disk, cross sections are handled on CPU.
     if (cross->do_cross(itime))
     {
+        master.print_message("Saving cross-sections for time %f\n", time);
+
         fields   ->exec_cross(*cross, iotime);
         thermo   ->exec_cross(*cross, iotime);
         microphys->exec_cross(*cross, iotime);
@@ -655,6 +653,8 @@ void Model<TF>::calculate_statistics(int iteration, double time, unsigned long i
     // Save the 3d dumps to disk.
     if (dump->do_dump(itime, idt))
     {
+        master.print_message("Saving field dumps for time %f\n", time);
+
         fields   ->exec_dump(*dump, iotime);
         thermo   ->exec_dump(*dump, iotime);
         microphys->exec_dump(*dump, iotime);

--- a/src/stats.cxx
+++ b/src/stats.cxx
@@ -745,9 +745,6 @@ void Stats<TF>::exec(const int iteration, const double time, const unsigned long
     auto& agd = grid.get_grid_data();
     auto& sgd = soil_grid.get_grid_data();
 
-    // Write message in case stats is triggered.
-    master.print_message("Saving statistics for time %f\n", time);
-
     // Finalize the total tendencies
     if (do_tendency())
     {


### PR DESCRIPTION
Potential fix for https://github.com/microhh/microhh/issues/265.
Not sure where we can best print the statistics message, since stats is split into the `some_process->exec_stats()` and the `stats->exec()` parts, with cross-sections and dumps in between.