### PR TITLE
Check idt, but also the value of the limiter idtlim being 0.

### DIFF
--- a/src/timeloop.cxx
+++ b/src/timeloop.cxx
@@ -234,7 +234,7 @@ void Timeloop<TF>::set_time_step()
 
     if (adaptivestep)
     {
-        if (idt == 0)
+        if (idt == 0 || idtlim == 0)
         {
             std::string msg = "Required time step less than precision " + std::to_string(1./ifactor) + " of the time stepping";
             throw std::runtime_error(msg);


### PR DESCRIPTION
Prevent the code for running with a time step of exactly 0