### PR TITLE
`exec_column` in `thermo_dry` was missing a base state copy.

### DIFF
--- a/src/thermo_dry.cxx
+++ b/src/thermo_dry.cxx
@@ -808,6 +808,8 @@ void Thermo_dry<TF>::exec_column(Column<TF>& column)
     const TF no_offset = 0.;
     auto output = fields.get_tmp();
 
+    bs_stats = bs;
+
     get_thermo_field(*output, "b",false, true);
     column.calc_column("b", output->fld.data(), no_offset);
 


### PR DESCRIPTION
`drycblles` + column stats segfaults on the CPU, because of a missing base state copy, similar to the one in `thermo_dry->exec_stats()` or `thermo_moist->exec_column()`.

No need to wrap the copy in `#ifndef USECUDA`, since that is already outside of `thermo_dry->exec_column()`