### PR TITLE
Don't saturation adjust surface in `get_radiation_fields/columns()`.

### DIFF
--- a/src/thermo_moist.cu
+++ b/src/thermo_moist.cu
@@ -522,7 +522,8 @@ namespace
             T[ijk_nogc] = ssa.t;
         }
 
-        if (i < iend && j < jend && k < kend+1)
+        // Exclude surface, is calculated below without saturation adjustment.
+        if (i < iend && j < jend && k > kstart && k < kend+1)
         {
             const TF exnh = exner(ph[k]);
             const int ijk = i + j*jj + k*kk;
@@ -540,8 +541,10 @@ namespace
             const TF exn_bot = exner(ph[kstart]);
             const int ij = i + j*jj;
             const int ij_nogc = (i-igc) + (j-jgc)*jj_nogc;
+            const int ijk_nogc = (i-igc) + (j-jgc)*jj_nogc + (kstart-kgc)*kk_nogc;
 
             T_sfc[ij_nogc] = thl_bot[ij] * exn_bot;
+            T_h[ijk_nogc] = T_sfc[ij_nogc];
         }
     }
 
@@ -584,7 +587,8 @@ namespace
             T[ijk_nogc] = ssa.t;
         }
 
-        if (i < iend && j < jend && k < kend+1)
+        // Exclude surface, is calculated below without saturation adjustment.
+        if (i < iend && j < jend && k > kstart && k < kend+1)
         {
             const TF exnh = exner(ph[k]);
             const int ijk = i + j*jj + k*kk;
@@ -602,8 +606,10 @@ namespace
             const TF exn_bot = exner(ph[kstart]);
             const int ij = i + j*jj;
             const int ij_nogc = (i-igc) + (j-jgc)*jj_nogc;
+            const int ijk_nogc = (i-igc) + (j-jgc)*jj_nogc + (kstart-kgc)*kk_nogc;
 
             T_sfc[ij_nogc] = thl_bot[ij] * exn_bot;
+            T_h[ijk_nogc] = T_sfc[ij_nogc];
         }
     }
 
@@ -650,7 +656,7 @@ namespace
                 T[ijk_out] = ssa.t;
             }
 
-            if (k < kend+1)
+            if (k > kstart && k < kend+1)
             {
                 const TF thlh = interp2(thl[ijk-ijcells], thl[ijk]);
                 const TF qth  = interp2(qt [ijk-ijcells], qt [ijk]);
@@ -659,7 +665,10 @@ namespace
             }
 
             if (k == kstart)
+            {
                 T_sfc[ij_out] = thl_bot[ij] * exner(ph[kstart]);
+                T_h[ijk_out] = T_sfc[ij_out];
+            }
         }
     }
 

--- a/src/thermo_moist.cxx
+++ b/src/thermo_moist.cxx
@@ -830,7 +830,8 @@ namespace
                 }
         }
 
-        for (int k=kstart; k<kend+1; ++k)
+        // Exclude surface, is calculated below without saturation adjustment.
+        for (int k=kstart+1; k<kend+1; ++k)
         {
             const TF exnh = exner(ph[k]);
             for (int j=jstart; j<jend; ++j)
@@ -853,7 +854,7 @@ namespace
                 }
         }
 
-        // Calculate surface temperature (assuming no liquid water)
+        // Calculate surface temperature (assuming no liquid water).
         const TF exn_bot = exner(ph[kstart]);
         for (int j=jstart; j<jend; ++j)
             #pragma ivdep
@@ -861,8 +862,10 @@ namespace
             {
                 const int ij = i + j*jj;
                 const int ij_nogc = (i-igc) + (j-jgc)*jj_nogc;
+                const int ijk_nogc = (i-igc) + (j-jgc)*jj_nogc + (kstart-kgc)*kk_nogc;
 
                 T_sfc[ij_nogc] = thl_bot[ij] * exn_bot;
+                T_h[ijk_nogc] = T_sfc[ij_nogc];
             }
     }
     
@@ -906,7 +909,8 @@ namespace
                 }
         }
 
-        for (int k=kstart; k<kend+1; ++k)
+        // Exclude surface, is calculated below without saturation adjustment.
+        for (int k=kstart+1; k<kend+1; ++k)
         {
             const TF exnh = exner(ph[k]);
             for (int j=jstart; j<jend; ++j)
@@ -929,7 +933,7 @@ namespace
                 }
         }
 
-        // Calculate surface temperature (assuming no liquid water)
+        // Calculate surface temperature (assuming no liquid water).
         const TF exn_bot = exner(ph[kstart]);
         for (int j=jstart; j<jend; ++j)
             #pragma ivdep
@@ -937,8 +941,10 @@ namespace
             {
                 const int ij = i + j*jj;
                 const int ij_nogc = (i-igc) + (j-jgc)*jj_nogc;
+                const int ijk_nogc = (i-igc) + (j-jgc)*jj_nogc + (kstart-kgc)*kk_nogc;
 
                 T_sfc[ij_nogc] = thl_bot[ij] * exn_bot;
+                T_h[ijk_nogc] = T_sfc[ij_nogc];
             }
     }
 
@@ -986,7 +992,8 @@ namespace
             }
         }
 
-        for (int k=kstart; k<kend+1; ++k)
+        // Exclude surface, is calculated below without saturation adjustment.
+        for (int k=kstart+1; k<kend+1; ++k)
         {
             const TF exnh = exner(ph[k]);
 
@@ -1017,8 +1024,10 @@ namespace
 
             const int ij = i + j*icells;
             const int ij_out = n;
+            const int ijk_out = n + (kstart-kgc)*n_cols;
 
             T_sfc[ij_out] = thl_bot[ij] * exn_bot;
+            T_h[ijk_out] = T_sfc[ij_out];
         }
     }
 
@@ -1065,7 +1074,6 @@ namespace
                 dqsdT[ij] = dqsatdT(ph[kstart], T_bot[ij]);
             }
     }
-
 }
 
 


### PR DESCRIPTION
See title. The surface temperature/humidity can be quite high in conditions with low wind / high ra, so better not to satadjust there, in line with the rest of the code.

Tested with Cabauw case, CPU + GPU.

Fixes https://github.com/microhh/microhh/issues/278