### PR TITLE
Check submodules with CMake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -152,6 +152,10 @@ if(USECUDA)
   endif()
 endif()
 
+if (NOT EXISTS "${CMAKE_SOURCE_DIR}/rte-rrtmgp-cpp/src")
+    message(FATAL_ERROR "Git submodules are not initialized. Please run:\n git submodule update --init --recursive")
+endif()
+
 add_subdirectory(rte-rrtmgp-cpp/src_kernels)
 if(USECUDA)
   add_subdirectory(rte-rrtmgp-cpp/src_kernels_cuda)

--- a/README.md
+++ b/README.md
@@ -30,14 +30,13 @@ In order to compile MicroHH you need:
 
 Downloading the code
 --------------------
-Check out the code from GitHub using
+MicroHH includes Git submodules, so it is essential to ensure these are downloaded properly when cloning the code. Check out the code with all submodules included using:
 
     git clone --recurse-submodules https://github.com/microhh/microhh.git
 
-In case you had already checked out the repository without checking out the submodules, use:
+If you get compilation errors related to missing RTE+RRTMGP source files, you probably forgot the `--recurse-submodules` flag. You can correct that with:
 
     git submodule update --init --recursive
-
 
 Compilation of the code
 -----------------------


### PR DESCRIPTION
Every new user runs into our Git submodule trap. This PR checks if one of the submodules is initialized, and if not, shows instructions on how to init them.

    bart@eddy:~/tmp/microhh/build_dp_cpu$ cmake -DSYST=ubuntu_20lts ..
    -- Precision: Double (64-bits floats)
    -- The CXX compiler identification is GNU 9.4.0
    -- The Fortran compiler identification is GNU 9.4.0
    -- Detecting CXX compiler ABI info
    -- Detecting CXX compiler ABI info - done
    -- Check for working CXX compiler: /usr/bin/g++ - skipped
    -- Detecting CXX compile features
    -- Detecting CXX compile features - done
    -- Detecting Fortran compiler ABI info
    -- Detecting Fortran compiler ABI info - done
    -- Check for working Fortran compiler: /usr/bin/gfortran - skipped
    -- MPI: Disabled.
    -- CUDA: Disabled.
    -- Build Type: RELEASE
    -- Compiler flags: -std=c++17 -O3 -march=native
    CMake Error at CMakeLists.txt:156 (message):
      Git submodules are not initialized.  Please run:
    
       git submodule update --init --recursive
    
    
    -- Configuring incomplete, errors occurred!
    bart@eddy:~/tmp/microhh/build_dp_cpu$ git submodule update --init --recursive
    Submodule 'external/kernel_launcher' (https://github.com/microhh/kernel_launcher) registered for path '../external/kernel_launcher'
    Submodule 'rte-rrtmgp-cpp' (https://github.com/microhh/rte-rrtmgp-cpp) registered for path '../rte-rrtmgp-cpp'
    Cloning into '/home/bart/tmp/microhh/external/kernel_launcher'...
    Cloning into '/home/bart/tmp/microhh/rte-rrtmgp-cpp'...
    Submodule path '../external/kernel_launcher': checked out '3220f904bfeecc702f9a8c2cba89282728e72fa2'
    Submodule path '../rte-rrtmgp-cpp': checked out '416a6706d732f58f379e74a9412370a21b39bcb2'
    Submodule 'rrtmgp-data' (https://github.com/earth-system-radiation/rrtmgp-data) registered for path '../rte-rrtmgp-cpp/rrtmgp-data'
    Submodule 'rte-rrtmgp' (https://github.com/earth-system-radiation/rte-rrtmgp) registered for path '../rte-rrtmgp-cpp/rte-rrtmgp'
    Cloning into '/home/bart/tmp/microhh/rte-rrtmgp-cpp/rrtmgp-data'...
    Cloning into '/home/bart/tmp/microhh/rte-rrtmgp-cpp/rte-rrtmgp'...
    Submodule path '../rte-rrtmgp-cpp/rrtmgp-data': checked out '4cff60d93f4d03668a9fecaf86b4131f589caa7e'
    Submodule path '../rte-rrtmgp-cpp/rte-rrtmgp': checked out 'e5d10ad692d340bcae4a50b8abdc7ca6bb74b73d'
    bart@eddy:~/tmp/microhh/build_dp_cpu$ cmake -DSYST=ubuntu_20lts ..
    -- Precision: Double (64-bits floats)
    -- MPI: Disabled.
    -- CUDA: Disabled.
    -- Compiler flags: -std=c++17 -O3 -march=native
    -- Found Git: /usr/bin/git (found version "2.25.1")
    -- Git hash 2.0.0_RC1-84-gdf300860-dirty
    -- Configuring done (0.1s)
    -- Generating done (0.0s)
    -- Build files have been written to: /home/bart/tmp/microhh/build_dp_cpu