### PR TITLE
Include constexpr, and merge sqrt division for performance.

### DIFF
--- a/include/diff_tke2_kl_kernels.cuh
+++ b/include/diff_tke2_kl_kernels.cuh
@@ -59,7 +59,7 @@ namespace Diff_tke2_kernels
             // Variables for the wall damping and length scales
             const TF n_mason = TF(2.);
     
-            if (!sw_surface_model)
+            if constexpr (!sw_surface_model)
                 asm("trap;");
             else
             {
@@ -68,17 +68,17 @@ namespace Diff_tke2_kernels
                 if (level.distance_to_start() == 0)
                 {
                     if ( bgradbot[ij] > 0 ) // Only if stably stratified, adapt length scale
-                        mlen = cn * sqrt(sgstke[ijk]) / sqrt(bgradbot[ij]);
+                        mlen = cn * sqrt(sgstke[ijk] / bgradbot[ij]);
                 }
                 else
                 {
                     if ( N2[ijk] > 0 ) // Only if stably stratified, adapt length scale
-                        mlen = cn * sqrt(sgstke[ijk]) / sqrt(N2[ijk]);
+                        mlen = cn * sqrt(sgstke[ijk] / N2[ijk]);
                 }
     
-                TF fac  = min(mlen0[k], mlen);
+                TF fac = min(mlen0[k], mlen);
     
-                if (sw_mason) // Apply Mason's wall correction here
+                if constexpr (sw_mason) // Apply Mason's wall correction here
                     fac = pow(TF(1.)/(TF(1.)/pow(fac, n_mason) + TF(1.)/
                             (pow(Constants::kappa<TF>*(z[k]+z0m[ij]), n_mason))), TF(1.)/n_mason);
     
@@ -116,7 +116,7 @@ namespace Diff_tke2_kernels
             // Variables for the wall damping and length scales
             const TF n_mason = TF(2.);
 
-            if (!sw_surface_model)
+            if constexpr (!sw_surface_model)
                 asm("trap;");
             else
             {
@@ -125,17 +125,17 @@ namespace Diff_tke2_kernels
                 if (level.distance_to_start() == 0)
                 {
                     if ( bgradbot[ij] > 0 ) // Only if stably stratified, adapt length scale
-                        mlen = cn * sqrt(sgstke[ijk]) / sqrt(bgradbot[ij]);
+                        mlen = cn * sqrt(sgstke[ijk] / bgradbot[ij]);
                 }
                 else
                 {
                     if ( N2[ijk] > 0 ) // Only if stably stratified, adapt length scale
-                        mlen = cn * sqrt(sgstke[ijk]) / sqrt(N2[ijk]);
+                        mlen = cn * sqrt(sgstke[ijk] / N2[ijk]);
                 }
 
                 TF fac = min(mlen0[k], mlen);
 
-                if (sw_mason) // Apply Mason's wall correction here
+                if constexpr (sw_mason) // Apply Mason's wall correction here
                     fac = pow(TF(1.)/(TF(1.)/pow(fac, n_mason) + TF(1.)/
                                 (pow(Constants::kappa<TF>*(z[k]+z0m[ij]), n_mason))), TF(1.)/n_mason);
 
@@ -178,18 +178,18 @@ namespace Diff_tke2_kernels
             if (level.distance_to_start() == 0)
             {
                 if (bgradbot[ij] > 0)
-                    mlen = cn * sqrt(a[ijk]) / sqrt(bgradbot[ij]);
+                    mlen = cn * sqrt(a[ijk] / bgradbot[ij]);
             }
             else
             {
                 if (N2[ijk] > 0)
-                    mlen = cn * sqrt(a[ijk]) / sqrt(N2[ijk]);
+                    mlen = cn * sqrt(a[ijk] / N2[ijk]);
             }
 
             TF fac  = min(mlen0[k], mlen);
 
             // Apply Mason's wall correction here
-            if (sw_mason)
+            if constexpr (sw_mason)
                 fac = pow(TF(1.)/(TF(1.)/pow(fac, n_mason) + TF(1.)/
                         (pow(Constants::kappa<TF>*(z[k]+z0m[ij]), n_mason))), TF(1.)/n_mason);
 

--- a/include/diff_tke2_kl_kernels.cuh
+++ b/include/diff_tke2_kl_kernels.cuh
@@ -79,8 +79,13 @@ namespace Diff_tke2_kernels
                 TF fac = min(mlen0[k], mlen);
     
                 if constexpr (sw_mason) // Apply Mason's wall correction here
-                    fac = pow(TF(1.)/(TF(1.)/pow(fac, n_mason) + TF(1.)/
-                            (pow(Constants::kappa<TF>*(z[k]+z0m[ij]), n_mason))), TF(1.)/n_mason);
+                {
+                    if constexpr (n_mason == 2)
+                        fac = sqrt(TF(1.) / ( TF(1.)/fm::pow2(fac) + TF(1.)/(fm::pow2(Constants::kappa<TF>*(z[k]+z0m[ij]))) ) );
+                    else
+                        fac = pow(TF(1.) / (TF(1.)/pow(fac, TF(n_mason)) + TF(1.)/
+                                    (pow(Constants::kappa<TF>*(z[k]+z0m[ij]), TF(n_mason)))), TF(1.)/TF(n_mason));
+                }
     
                 // Calculate eddy diffusivity for momentum.
                 evisc[ijk] = cm * fac * sqrt(sgstke[ijk]);
@@ -136,8 +141,13 @@ namespace Diff_tke2_kernels
                 TF fac = min(mlen0[k], mlen);
 
                 if constexpr (sw_mason) // Apply Mason's wall correction here
-                    fac = pow(TF(1.)/(TF(1.)/pow(fac, n_mason) + TF(1.)/
-                                (pow(Constants::kappa<TF>*(z[k]+z0m[ij]), n_mason))), TF(1.)/n_mason);
+                {
+                    if constexpr (n_mason == 2)
+                        fac = sqrt(TF(1.) / ( TF(1.)/fm::pow2(fac) + TF(1.)/(fm::pow2(Constants::kappa<TF>*(z[k]+z0m[ij]))) ) );
+                    else
+                        fac = pow(TF(1.) / (TF(1.)/pow(fac, TF(n_mason)) + TF(1.)/
+                                    (pow(Constants::kappa<TF>*(z[k]+z0m[ij]), TF(n_mason)))), TF(1.)/TF(n_mason));
+                }
 
                 // Calculate eddy diffusivity for momentum.
                 evisch[ijk] = (ch1 + ch2 * fac / mlen0[k]) * evisc[ijk];
@@ -186,12 +196,16 @@ namespace Diff_tke2_kernels
                     mlen = cn * sqrt(a[ijk] / N2[ijk]);
             }
 
-            TF fac  = min(mlen0[k], mlen);
+            TF fac = min(mlen0[k], mlen);
 
-            // Apply Mason's wall correction here
-            if constexpr (sw_mason)
-                fac = pow(TF(1.)/(TF(1.)/pow(fac, n_mason) + TF(1.)/
-                        (pow(Constants::kappa<TF>*(z[k]+z0m[ij]), n_mason))), TF(1.)/n_mason);
+            if constexpr (sw_mason) // Apply Mason's wall correction here
+            {
+                if constexpr (n_mason == 2)
+                    fac = sqrt(TF(1.) / ( TF(1.)/fm::pow2(fac) + TF(1.)/(fm::pow2(Constants::kappa<TF>*(z[k]+z0m[ij]))) ) );
+                else
+                    fac = pow(TF(1.) / (TF(1.)/pow(fac, TF(n_mason)) + TF(1.)/
+                                (pow(Constants::kappa<TF>*(z[k]+z0m[ij]), TF(n_mason)))), TF(1.)/TF(n_mason));
+            }
 
             // Calculate dissipation of SGS TKE based on Deardorff (1980)
             at[ijk] -= (ce1 + ce2 * fac / mlen0[k]) * pow(a[ijk], TF(3./2.)) / fac;

--- a/src/diff_tke2.cu
+++ b/src/diff_tke2.cu
@@ -74,6 +74,7 @@ namespace
         constexpr TF A_vandriest = TF(26.);
 
         TF fac;
+
         if (i < iend && j < jend && k < kend)
         {
             const int ij = i + j*jj;
@@ -83,9 +84,14 @@ namespace
                 asm("trap;");
             else
             {
-                if (sw_mason) // Apply Mason's wall correction
-                    fac = pow(TF(1.)/(TF(1.)/pow(mlen0[k], n_mason) + TF(1.)/
-                                (pow(Constants::kappa<TF>*(z[k]+z0m[ij]), n_mason))), TF(1.)/n_mason);
+                if constexpr (sw_mason) // Apply Mason's wall correction here
+                {
+                    if constexpr (n_mason == 2)
+                        fac = std::sqrt(TF(1.) / ( TF(1.)/fm::pow2(mlen0[k]) + TF(1.)/(fm::pow2(Constants::kappa<TF>*(z[k]+z0m[ij]))) ) );
+                    else
+                        fac = std::pow(TF(1.) / (TF(1.)/std::pow(mlen0[k], TF(n_mason)) + TF(1.)/
+                                    (std::pow(Constants::kappa<TF>*(z[k]+z0m[ij]), TF(n_mason)))), TF(1.)/TF(n_mason));
+                }
                 else
                     fac = mlen0[k];
 
@@ -127,9 +133,14 @@ namespace
 
             fac = mlen0[k];
 
-            if (sw_mason) // Apply Mason's wall correction here
-                fac = pow(TF(1.)/(TF(1.)/pow(mlen0[k], n_mason) + TF(1.)/
-                        (pow(Constants::kappa<TF>*(z[k]+z0m[ij]), n_mason))), TF(1.)/n_mason);
+            if constexpr (sw_mason) // Apply Mason's wall correction here
+            {
+                if constexpr (n_mason == 2)
+                    fac = sqrt(TF(1.) / ( TF(1.)/fm::pow2(mlen0[k]) + TF(1.)/(fm::pow2(Constants::kappa<TF>*(z[k]+z0m[ij]))) ) );
+                else
+                    fac = pow(TF(1.) / (TF(1.)/std::pow(mlen0[k], TF(n_mason)) + TF(1.)/
+                                (pow(Constants::kappa<TF>*(z[k]+z0m[ij]), TF(n_mason)))), TF(1.)/TF(n_mason));
+            }
 
             // Calculate dissipation of SGS TKE based on Deardorff (1980)
             at[ijk] -= (ce1 + ce2 * fac / mlen0[k]) * pow(a[ijk], TF(3./2.)) / fac ;

--- a/src/diff_tke2.cxx
+++ b/src/diff_tke2.cxx
@@ -110,11 +110,17 @@ namespace
                     {
                         const int ij = i + j*jj;
                         const int ijk = i + j*jj + k*kk;
+
                         TF fac;
 
-                        if (sw_mason) // Apply Mason's wall correction
-                            fac = std::pow(TF(1.)/(TF(1.)/std::pow(mlen0, n_mason) + TF(1.)/
-                                        (std::pow(Constants::kappa<TF>*(z[k]+z0m[ij]), n_mason))), TF(1.)/n_mason);
+                        if constexpr (sw_mason) // Apply Mason's wall correction
+                        {
+                            if constexpr (n_mason == 2)
+                                fac = std::sqrt(TF(1.) / ( TF(1.)/fm::pow2(mlen0) + TF(1.)/(fm::pow2(Constants::kappa<TF>*(z[kstart]+z0m[ij]))) ) );
+                            else
+                                fac = std::pow(TF(1.) / (TF(1.)/std::pow(mlen0, TF(n_mason)) + TF(1.)/
+                                            (std::pow(Constants::kappa<TF>*(z[k]+z0m[ij]), TF(n_mason)))), TF(1.)/TF(n_mason));
+                        }
                         else
                             fac = mlen0;
 
@@ -155,7 +161,8 @@ namespace
        else
        {
             // Variables for the wall damping and length scales
-            const TF n_mason = TF(2.);
+            constexpr int n_mason = 2;
+
             TF mlen;
             TF fac;
 
@@ -174,11 +181,16 @@ namespace
                     else
                         mlen = mlen0;
 
-                    fac  = std::min(mlen0, mlen);
+                    fac = std::min(mlen0, mlen);
 
                     if constexpr (sw_mason) // Apply Mason's wall correction here
-                        fac = std::pow(TF(1.)/(TF(1.)/std::pow(fac, n_mason) + TF(1.)/
-                                    (std::pow(Constants::kappa<TF>*(z[kstart]+z0m[ij]), n_mason))), TF(1.)/n_mason);
+                    {
+                        if constexpr (n_mason == 2)
+                            fac = std::sqrt(TF(1.) / ( TF(1.)/fm::pow2(fac) + TF(1.)/(fm::pow2(Constants::kappa<TF>*(z[kstart]+z0m[ij]))) ) );
+                        else
+                            fac = std::pow(TF(1.) / (TF(1.)/std::pow(fac, TF(n_mason)) + TF(1.)/
+                                        (std::pow(Constants::kappa<TF>*(z[kstart]+z0m[ij]), TF(n_mason)))), TF(1.)/TF(n_mason));
+                    }
 
                     // Calculate eddy diffusivity for momentum.
                     evisc[ijk] = cm * fac * std::sqrt(sgstke[ijk]);
@@ -201,11 +213,16 @@ namespace
                         else
                             mlen = mlen0;
 
-                        fac  = std::min(mlen0, mlen);
+                        fac = std::min(mlen0, mlen);
 
                         if constexpr (sw_mason) // Apply Mason's wall correction here
-                            fac = std::pow(TF(1.)/(TF(1.)/std::pow(fac, n_mason) + TF(1.)/
-                                        (std::pow(Constants::kappa<TF>*(z[k]+z0m[ij]), n_mason))), TF(1.)/n_mason);
+                        {
+                            if constexpr (n_mason == 2)
+                                fac = std::sqrt(TF(1.) / ( TF(1.)/fm::pow2(fac) + TF(1.)/(fm::pow2(Constants::kappa<TF>*(z[k]+z0m[ij]))) ) );
+                            else
+                                fac = std::pow(TF(1.) / (TF(1.)/std::pow(fac, TF(n_mason)) + TF(1.)/
+                                            (std::pow(Constants::kappa<TF>*(z[k]+z0m[ij]), TF(n_mason)))), TF(1.)/TF(n_mason));
+                        }
 
                         // Calculate eddy diffusivity for momentum.
                         evisc[ijk] = cm * fac * std::sqrt(sgstke[ijk]);
@@ -242,7 +259,8 @@ namespace
         else
         {
             // Variables for the wall damping and length scales
-            const TF n_mason = TF(2.);
+            constexpr int n_mason = 2;
+
             TF mlen;
             TF fac;
 
@@ -257,15 +275,20 @@ namespace
                     const int ijk = i + j*jj + kstart*kk;
 
                     if ( bgradbot[ij] > 0 ) // Only if stably stratified, adapt length scale
-                        mlen = cn * std::sqrt(sgstke[ijk]) / std::sqrt(bgradbot[ij]);
+                        mlen = cn * std::sqrt(sgstke[ijk] / bgradbot[ij]);
                     else
                         mlen = mlen0;
 
-                    fac  = std::min(mlen0, mlen);
+                    fac = std::min(mlen0, mlen);
 
-                    if (sw_mason) // Apply Mason's wall correction here
-                        fac = std::pow(TF(1.)/(TF(1.)/std::pow(fac, n_mason) + TF(1.)/
-                                    (std::pow(Constants::kappa<TF>*(z[kstart]+z0m[ij]), n_mason))), TF(1.)/n_mason);
+                    if constexpr (sw_mason) // Apply Mason's wall correction here
+                    {
+                        if constexpr (n_mason == 2)
+                            fac = std::sqrt(TF(1.) / ( TF(1.)/fm::pow2(fac) + TF(1.)/(fm::pow2(Constants::kappa<TF>*(z[kstart]+z0m[ij]))) ) );
+                        else
+                            fac = std::pow(TF(1.) / (TF(1.)/std::pow(fac, TF(n_mason)) + TF(1.)/
+                                        (std::pow(Constants::kappa<TF>*(z[kstart]+z0m[ij]), TF(n_mason)))), TF(1.)/TF(n_mason));
+                    }
 
                     // Calculate eddy diffusivity for momentum.
                     evisch[ijk] = (ch1 + ch2 * fac / mlen0 ) * evisc[ijk];
@@ -284,15 +307,20 @@ namespace
                         const int ijk = i + j*jj + k*kk;
 
                         if ( N2[ijk] > 0 ) // Only if stably stratified, adapt length scale
-                            mlen = cn * std::sqrt(sgstke[ijk]) / std::sqrt(N2[ijk]);
+                            mlen = cn * std::sqrt(sgstke[ijk] / N2[ijk]);
                         else
                             mlen = mlen0;
 
-                        fac  = std::min(mlen0, mlen);
+                        fac = std::min(mlen0, mlen);
 
-                        if (sw_mason) // Apply Mason's wall correction here
-                            fac = std::pow(TF(1.)/(TF(1.)/std::pow(fac, n_mason) + TF(1.)/
-                                        (std::pow(Constants::kappa<TF>*(z[k]+z0m[ij]), n_mason))), TF(1.)/n_mason);
+                        if constexpr (sw_mason) // Apply Mason's wall correction here
+                        {
+                            if constexpr (n_mason == 2)
+                                fac = std::sqrt(TF(1.) / ( TF(1.)/fm::pow2(fac) + TF(1.)/(fm::pow2(Constants::kappa<TF>*(z[k]+z0m[ij]))) ) );
+                            else
+                                fac = std::pow(TF(1.) / (TF(1.)/std::pow(fac, TF(n_mason)) + TF(1.)/
+                                            (std::pow(Constants::kappa<TF>*(z[k]+z0m[ij]), TF(n_mason)))), TF(1.)/TF(n_mason));
+                        }
 
                         // Calculate eddy diffusivity for momentum.
                         evisch[ijk] = (ch1 + ch2 * fac / mlen0 ) * evisc[ijk];

--- a/src/diff_tke2.cxx
+++ b/src/diff_tke2.cxx
@@ -170,13 +170,13 @@ namespace
                     const int ijk = i + j*jj + kstart*kk;
 
                     if ( bgradbot[ij] > 0 ) // Only if stably stratified, adapt length scale
-                        mlen = cn * std::sqrt(sgstke[ijk]) / std::sqrt(bgradbot[ij]);
+                        mlen = cn * std::sqrt(sgstke[ijk] / bgradbot[ij]);
                     else
                         mlen = mlen0;
 
                     fac  = std::min(mlen0, mlen);
 
-                    if (sw_mason) // Apply Mason's wall correction here
+                    if constexpr (sw_mason) // Apply Mason's wall correction here
                         fac = std::pow(TF(1.)/(TF(1.)/std::pow(fac, n_mason) + TF(1.)/
                                     (std::pow(Constants::kappa<TF>*(z[kstart]+z0m[ij]), n_mason))), TF(1.)/n_mason);
 
@@ -197,13 +197,13 @@ namespace
                         const int ijk = i + j*jj + k*kk;
 
                         if (N2[ijk] > 0) // Only if stably stratified, adapt length scale
-                            mlen = cn * std::sqrt(sgstke[ijk]) / std::sqrt(N2[ijk]);
+                            mlen = cn * std::sqrt(sgstke[ijk] / N2[ijk]);
                         else
                             mlen = mlen0;
 
                         fac  = std::min(mlen0, mlen);
 
-                        if (sw_mason) // Apply Mason's wall correction here
+                        if constexpr (sw_mason) // Apply Mason's wall correction here
                             fac = std::pow(TF(1.)/(TF(1.)/std::pow(fac, n_mason) + TF(1.)/
                                         (std::pow(Constants::kappa<TF>*(z[k]+z0m[ij]), n_mason))), TF(1.)/n_mason);
 


### PR DESCRIPTION
A few small performance tweaks, helps to speed up `diff2_tke` kernels in `double` mode. Can directly be merged into `develop` as well.