### PR TITLE
Make `line_xyz` in `source` optional, and default to list with zeros.

### DIFF
--- a/cases/dispersion/dispersion_base.ini
+++ b/cases/dispersion/dispersion_base.ini
@@ -76,9 +76,9 @@ sigma_y=None
 sigma_z=None
 strength=None
 swvmr=None
-line_x=None
-line_y=None
-line_z=None
+#line_x=None
+#line_y=None
+#line_z=None
 
 [buffer]
 swbuffer=1

--- a/cases/dispersion/dispersion_input.py
+++ b/cases/dispersion/dispersion_input.py
@@ -114,9 +114,9 @@ ini['source']['sigma_y'] = const_list(sigma_y)
 ini['source']['sigma_z'] = const_list(sigma_z)
 ini['source']['strength'] = const_list(strength)
 ini['source']['swvmr'] = const_list(sw_vmr)
-ini['source']['line_x'] = const_list(0)
-ini['source']['line_y'] = const_list(0)
-ini['source']['line_z'] = const_list(0)
+#ini['source']['line_x'] = const_list(0)
+#ini['source']['line_y'] = const_list(0)
+#ini['source']['line_z'] = const_list(0)
 
 # Statistics/crosses/...
 scalar_crosses = scalars + [s+'_path' for s in scalars]

--- a/src/source.cxx
+++ b/src/source.cxx
@@ -172,13 +172,27 @@ Source<TF>::Source(Master& master, Grid<TF>& grid, Fields<TF>& fields, Input& in
         source_x0 = input.get_list<TF>("source", "source_x0", "");
         source_y0 = input.get_list<TF>("source", "source_y0", "");
         source_z0 = input.get_list<TF>("source", "source_z0", "");
-        sigma_x   = input.get_list<TF>("source", "sigma_x"  , "");
-        sigma_y   = input.get_list<TF>("source", "sigma_y"  , "");
-        sigma_z   = input.get_list<TF>("source", "sigma_z"  , "");
-        strength  = input.get_list<TF>("source", "strength" , "");
-        line_x    = input.get_list<TF>("source", "line_x"   , "");
-        line_y    = input.get_list<TF>("source", "line_y"   , "");
-        line_z    = input.get_list<TF>("source", "line_z"   , "");
+        sigma_x   = input.get_list<TF>("source", "sigma_x",   "");
+        sigma_y   = input.get_list<TF>("source", "sigma_y",   "");
+        sigma_z   = input.get_list<TF>("source", "sigma_z",   "");
+        strength  = input.get_list<TF>("source", "strength",  "");
+        line_x    = input.get_list<TF>("source", "line_x",    "", std::vector<TF>());
+        line_y    = input.get_list<TF>("source", "line_y",    "", std::vector<TF>());
+        line_z    = input.get_list<TF>("source", "line_z",    "", std::vector<TF>());
+
+        auto check_and_default = [&](std::vector<TF>& vec)
+        {
+            if (vec.size() == 0 && source_x0.size() > 0)
+            {
+                vec.resize(source_x0.size());
+                std::fill(vec.begin(), vec.end(), TF(0));
+            }
+        };
+
+        // The `line_` input options are allowed to be empty. Set to zero if size differs from other input options.
+        check_and_default(line_x);
+        check_and_default(line_y);
+        check_and_default(line_z);
 
         // Timedep source location
         swtimedep_location = input.get_item<bool>("source", "swtimedep_location", "", false);

--- a/src/source.cxx
+++ b/src/source.cxx
@@ -182,7 +182,9 @@ Source<TF>::Source(Master& master, Grid<TF>& grid, Fields<TF>& fields, Input& in
 
         auto check_and_default = [&](std::vector<TF>& vec)
         {
-            if (vec.size() == 0 && source_x0.size() > 0)
+            if (vec.size() > 0 && vec.size() != source_x0.size())
+                throw std::runtime_error("Number of line input values doesn't match other source input values.");
+            else if (vec.size() == 0 && source_x0.size() > 0)
             {
                 vec.resize(source_x0.size());
                 std::fill(vec.begin(), vec.end(), TF(0));


### PR DESCRIPTION
Kept it simple; `line_x` et al. are optional now, and default to an empty list. If not specified in the .ini, these vectors are resized to the size of `source_x`, and filled with zeros.

Tested with the `dispersion` case, which no longer specifies `list_xyz` (previously these were set to `0,0`).

    [source][line_x]              =  EMPTY LIST   (default)
    [source][line_y]              =  EMPTY LIST   (default)
    [source][line_z]              =  EMPTY LIST   (default)
