### PR TITLE
A-Gs + bulk stability

### DIFF
--- a/cases/arm/arm_test.py
+++ b/cases/arm/arm_test.py
@@ -1,0 +1,43 @@
+from copy import deepcopy
+import sys
+import os
+import copy
+import shutil
+
+sys.path.append('../../python/')
+import microhh_tools as mht
+
+# Case configuration dicts
+no_opts = {}
+
+opt_mpi = {
+        'master': {'npx': 2, 'npy': 2}}
+
+opt_small = {
+        'grid': {'xsize': 800, 'ysize': 800, 'itot': 8, 'jtot': 8},
+        'time': {'endtime': 1800, 'savetime': 900}}
+
+# Case configuration dicts with name label for permutations.
+dict_opts = {
+        'default': {}}
+
+if __name__ == '__main__':
+
+    case_name = 'arm'
+
+    kwargs = dict([arg.split('=') for arg in sys.argv[2:]])
+
+    if len(sys.argv) > 1:
+        function_name = sys.argv[1]
+
+        if function_name == 'run_case':
+            mht.run_case(case_name, no_opts, opt_mpi, **kwargs)
+        elif function_name == 'run_small':
+            mht.run_case(case_name, opt_small, opt_mpi, **kwargs)
+        elif function_name == 'run_restart':
+            mht.run_restart(case_name, opt_small, opt_mpi, dict_opts, **kwargs)
+        else:
+            raise Exception('\"{}\" is an invalid option'.format(function_name))
+
+    else:
+        mht.run_case(case_name, no_opts, opt_mpi)

--- a/cases/cabauw/cabauw.ini.base
+++ b/cases/cabauw/cabauw.ini.base
@@ -92,6 +92,9 @@ lambda_stable=10.0
 lambda_unstable=10.0
 cs_veg=0
 
+swags=0
+ags_index=0  # 0=grass.
+
 [force]
 swlspres=geo
 swtimedep_geo=1

--- a/cases/cabauw/cabauw.ini.base
+++ b/cases/cabauw/cabauw.ini.base
@@ -80,6 +80,8 @@ swtilestats=0
 swtilestats_column=0
 switerseb=0
 swwater=0
+swags=None
+
 ktot=4
 
 gD=0.0
@@ -90,9 +92,6 @@ rs_soil_min=50
 lambda_stable=10.0
 lambda_unstable=10.0
 cs_veg=0
-
-swags=0
-ags_index=0  # 0=grass.
 
 [force]
 swlspres=geo

--- a/cases/cabauw/cabauw.ini.base
+++ b/cases/cabauw/cabauw.ini.base
@@ -22,7 +22,7 @@ swspatialorder=2
 [advec]
 swadvec=2i5
 cflmax=1.4
-fluxlimit_list=qt,qr,nr
+fluxlimit_list=None
 
 [diff]
 swdiff=smag2
@@ -31,12 +31,12 @@ dnmax=0.4
 [thermo]
 swthermo=moist
 swbasestate=anelastic
-pbot=1e5
+pbot=-1
 swupdatebasestate=1
 swtimedep_pbot=1
 
 [micro]
-swmicro=2mom_warm
+swmicro=None
 cflmax=1.2
 Nc0=200000000
 Ni0=1e5
@@ -54,7 +54,6 @@ sfc_alb_dif=0.22
 swclearskystats=1
 swfixedsza=0
 swtimedep_background=None
-#timedeplist_gas=None
 
 [aerosol]
 swaerosol=None
@@ -155,4 +154,4 @@ coordinates[x]=None
 coordinates[y]=None
 
 [limiter]
-limitlist=qt,qr,nr
+limitlist=None

--- a/cases/cabauw/cabauw_input.py
+++ b/cases/cabauw/cabauw_input.py
@@ -35,6 +35,7 @@ def create_case_input(
         use_homogeneous_z0,
         use_homogeneous_ls,
         gpt_set,
+        sw_micro,
         itot, jtot, ktot,
         xsize, ysize, zsize,
         TF,
@@ -83,6 +84,11 @@ def create_case_input(
     # Interpolate to LES levels and ERA5 time (CAMS is 3-hourly).
     cams = cams.interp(time=ls2d.time)
     cams_z = cams.interp(z=z)
+
+    # Make sure aerosol concentrations are >= 0.
+    for v in cams_z:
+        if 'aermr' in v:
+            cams_z[v] = np.maximum(cams_z[v], 0.)
 
     if not use_rrtmgp:
         # Read ERA5 radiation, de-accumulate, and interpolate to LS2D times.
@@ -162,6 +168,19 @@ def create_case_input(
 
     if heterogeneous_sfc:
         ini['stats']['xymasklist'] = ['wet_mask', 'dry_mask']
+
+    if sw_micro == 'nsw6':
+        ini['micro']['swmicro'] = sw_micro
+        ini['advec']['fluxlimit_list'] = ['qt', 'qr', 'qs', 'qg']
+        ini['limiter']['limitlist'] = ['qt', 'qr', 'qs', 'qg']
+    elif sw_micro == '2mom_warm':
+        ini['micro']['swmicro'] = sw_micro
+        ini['advec']['fluxlimit_list'] = ['qt', 'qr', 'nr']
+        ini['limiter']['limitlist'] = ['qt', 'qr', 'nr']
+    else:
+        ini['micro']['swmicro'] = False
+        ini['advec']['fluxlimit_list'] = ['qt']
+        ini['limiter']['limitlist'] = ['qt']
 
     ini['column']['coordinates[x]'] = xsize/2
     ini['column']['coordinates[y]'] = ysize/2
@@ -487,6 +506,8 @@ if __name__ == '__main__':
     use_tdep_gasses = False      # False = time fixed ERA5 (o3) and CAMS (co2, ch4) gasses.
     use_tdep_background = False  # False = time fixed RRTMGP T/h2o/o3 background profiles.
 
+    sw_micro = '2mom_warm'
+
     """
     NOTE: `use_tdep_aerosols` and `use_tdep_gasses` specify whether the aerosols and gasses
           used by RRTMGP are updated inside the LES domain. If `use_tdep_background` is true, the
@@ -526,8 +547,9 @@ if __name__ == '__main__':
             use_homogeneous_z0,
             use_homogeneous_ls,
             gpt_set,
+            sw_micro,
             itot, jtot, ktot,
             xsize, ysize, zsize,
             TF,
-            npx=2,
-            npy=4)
+            npx=1,
+            npy=1)

--- a/cases/cabauw/cabauw_input.py
+++ b/cases/cabauw/cabauw_input.py
@@ -496,7 +496,7 @@ if __name__ == '__main__':
     """
     TF = np.float64              # Switch between double (float64) and single (float32) precision.
     use_htessel = True           # False = prescribed surface H+LE fluxes from ERA5.
-    use_ags = True               # False = Jarvis-Stewart, True = A-Gs.
+    use_ags = False               # False = Jarvis-Stewart, True = A-Gs.
     use_rrtmgp = True            # False = prescribed surface radiation from ERA5.
     use_rt = False               # False = 2stream solver for shortwave down, True = raytracer.
     use_homogeneous_z0 = True    # False = checkerboard pattern roughness lengths.
@@ -551,5 +551,5 @@ if __name__ == '__main__':
             itot, jtot, ktot,
             xsize, ysize, zsize,
             TF,
-            npx=2,
-            npy=2)
+            npx=1,
+            npy=1)

--- a/cases/cabauw/cabauw_input.py
+++ b/cases/cabauw/cabauw_input.py
@@ -496,7 +496,7 @@ if __name__ == '__main__':
     """
     TF = np.float64              # Switch between double (float64) and single (float32) precision.
     use_htessel = True           # False = prescribed surface H+LE fluxes from ERA5.
-    use_ags = False               # False = Jarvis-Stewart, True = A-Gs.
+    use_ags = True               # False = Jarvis-Stewart, True = A-Gs.
     use_rrtmgp = True            # False = prescribed surface radiation from ERA5.
     use_rt = False               # False = 2stream solver for shortwave down, True = raytracer.
     use_homogeneous_z0 = True    # False = checkerboard pattern roughness lengths.

--- a/cases/cabauw/cabauw_input.py
+++ b/cases/cabauw/cabauw_input.py
@@ -228,8 +228,8 @@ def create_case_input(
     Time varying forcings
     """
     nc_tdep = nc.createGroup('timedep')
-    add_nc_dim('time_surface', ls2d_z.dims['time'], nc_tdep)
-    add_nc_dim('time_ls', ls2d_z.dims['time'], nc_tdep)
+    add_nc_dim('time_surface', ls2d_z.sizes['time'], nc_tdep)
+    add_nc_dim('time_ls', ls2d_z.sizes['time'], nc_tdep)
 
     add_nc_var('time_surface', ('time_surface'), nc_tdep, ls2d_z.time_sec)
     add_nc_var('time_ls', ('time_surface'), nc_tdep, ls2d_z.time_sec)
@@ -264,8 +264,8 @@ def create_case_input(
     """
     if use_rrtmgp:
         nc_rad = nc.createGroup('radiation')
-        add_nc_dim('lay', ls2d_z.dims['lay'], nc_rad)
-        add_nc_dim('lev', ls2d_z.dims['lev'], nc_rad)
+        add_nc_dim('lay', ls2d_z.sizes['lay'], nc_rad)
+        add_nc_dim('lev', ls2d_z.sizes['lev'], nc_rad)
 
         # Radiation variables on LES grid.
         xm_air = 28.97; xm_h2o = 18.01528; eps = xm_h2o / xm_air
@@ -296,11 +296,11 @@ def create_case_input(
 
         if use_tdep_background or use_tdep_aerosols or use_tdep_gasses:
             # NOTE: bit cheap, but ERA and CAMS are at the same time period/interval here.
-            add_nc_dim('time_rad', ls2d_z.dims['time'], nc_tdep)
+            add_nc_dim('time_rad', ls2d_z.sizes['time'], nc_tdep)
             add_nc_var('time_rad', ('time_rad'), nc_tdep, ls2d_z.time_sec)
 
-            add_nc_dim('lay', ls2d_z.dims['lay'], nc_tdep)
-            add_nc_dim('lev', ls2d_z.dims['lev'], nc_tdep)
+            add_nc_dim('lay', ls2d_z.sizes['lay'], nc_tdep)
+            add_nc_dim('lev', ls2d_z.sizes['lev'], nc_tdep)
 
         if use_tdep_gasses:
             add_nc_var('o3',  ('time_rad', 'z'), nc_tdep, ls2d_z.o3*1e-6)
@@ -376,7 +376,7 @@ def create_case_input(
     """
     if use_htessel:
         nc_soil = nc.createGroup('soil')
-        nc_soil.createDimension('z', ls2d_z.dims['zs'])
+        nc_soil.createDimension('z', ls2d_z.sizes['zs'])
         add_nc_var('z', ('z'), nc_soil, ls2d.zs[::-1])
 
         add_nc_var('theta_soil', ('z'), nc_soil, theta_soil)

--- a/cases/cabauw/cabauw_input.py
+++ b/cases/cabauw/cabauw_input.py
@@ -134,6 +134,7 @@ def create_case_input(
         ini['land_surface']['swags'] = use_ags
         if use_ags:
             ini['fields']['slist'] = 'co2'
+            ini['boundary']['sbcbot[co2]'] = 'flux'
     else:
         ini['boundary']['swboundary'] = 'surface'
         ini['boundary']['sbcbot'] = 'flux'

--- a/cases/cabauw/cabauw_input.py
+++ b/cases/cabauw/cabauw_input.py
@@ -25,6 +25,7 @@ def create_case_input(
         start_date,
         end_date,
         use_htessel,
+        use_ags,
         use_rrtmgp,
         use_rt,
         use_aerosols,
@@ -123,6 +124,8 @@ def create_case_input(
     if use_htessel:
         ini['boundary']['swboundary'] = 'surface_lsm'
         ini['boundary']['sbcbot'] = 'dirichlet'
+
+        ini['land_surface']['swags'] = use_ags
     else:
         ini['boundary']['swboundary'] = 'surface'
         ini['boundary']['sbcbot'] = 'flux'
@@ -470,6 +473,7 @@ if __name__ == '__main__':
     """
     TF = np.float64              # Switch between double (float64) and single (float32) precision.
     use_htessel = True           # False = prescribed surface H+LE fluxes from ERA5.
+    use_ags = True               # False = Jarvis-Stewart, True = A-Gs.
     use_rrtmgp = True            # False = prescribed surface radiation from ERA5.
     use_rt = False               # False = 2stream solver for shortwave down, True = raytracer.
     use_homogeneous_z0 = True    # False = checkerboard pattern roughness lengths.
@@ -497,17 +501,18 @@ if __name__ == '__main__':
     zsize = 4000
     ktot = 160
 
-    itot = 512
-    jtot = 512
+    itot = 32
+    jtot = 32
 
-    xsize = 25600
-    ysize = 25600
+    xsize = 3200
+    ysize = 3200
 
     # Create input files.
     create_case_input(
             start_date,
             end_date,
             use_htessel,
+            use_ags,
             use_rrtmgp,
             use_rt,
             use_aerosols,

--- a/cases/cabauw/cabauw_input.py
+++ b/cases/cabauw/cabauw_input.py
@@ -496,7 +496,7 @@ if __name__ == '__main__':
     """
     TF = np.float64              # Switch between double (float64) and single (float32) precision.
     use_htessel = True           # False = prescribed surface H+LE fluxes from ERA5.
-    use_ags = True               # False = Jarvis-Stewart, True = A-Gs.
+    use_ags = False              # False = Jarvis-Stewart, True = A-Gs.
     use_rrtmgp = True            # False = prescribed surface radiation from ERA5.
     use_rt = False               # False = 2stream solver for shortwave down, True = raytracer.
     use_homogeneous_z0 = True    # False = checkerboard pattern roughness lengths.

--- a/cases/cabauw/cabauw_input.py
+++ b/cases/cabauw/cabauw_input.py
@@ -526,8 +526,8 @@ if __name__ == '__main__':
     zsize = 4000
     ktot = 160
 
-    itot = 16
-    jtot = 16
+    itot = 8
+    jtot = 8
 
     xsize = 1600
     ysize = 1600
@@ -551,5 +551,5 @@ if __name__ == '__main__':
             itot, jtot, ktot,
             xsize, ysize, zsize,
             TF,
-            npx=1,
-            npy=1)
+            npx=2,
+            npy=2)

--- a/cases/cabauw/cabauw_input.py
+++ b/cases/cabauw/cabauw_input.py
@@ -126,6 +126,8 @@ def create_case_input(
         ini['boundary']['sbcbot'] = 'dirichlet'
 
         ini['land_surface']['swags'] = use_ags
+        if use_ags:
+            ini['fields']['slist'] = 'co2'
     else:
         ini['boundary']['swboundary'] = 'surface'
         ini['boundary']['sbcbot'] = 'flux'
@@ -197,6 +199,8 @@ def create_case_input(
     nc_init = nc.createGroup('init')
     add_nc_var('thl', ('z'), nc_init, ls2d_z.thl[0,:])
     add_nc_var('qt', ('z'), nc_init, ls2d_z.qt[0,:])
+    if use_ags:
+        add_nc_var('co2', ('z'), nc_init, cams_z.co2[0,:])
     add_nc_var('u', ('z'), nc_init, ls2d_z.u[0,:])
     add_nc_var('v', ('z'), nc_init, ls2d_z.v[0,:])
     add_nc_var('nudgefac', ('z'), nc_init, np.ones(ktot)/10800)
@@ -501,11 +505,11 @@ if __name__ == '__main__':
     zsize = 4000
     ktot = 160
 
-    itot = 32
-    jtot = 32
+    itot = 16
+    jtot = 16
 
-    xsize = 3200
-    ysize = 3200
+    xsize = 1600
+    ysize = 1600
 
     # Create input files.
     create_case_input(
@@ -526,4 +530,4 @@ if __name__ == '__main__':
             xsize, ysize, zsize,
             TF,
             npx=2,
-            npy=2)
+            npy=4)

--- a/cases/cabauw/cabauw_restart_test.py
+++ b/cases/cabauw/cabauw_restart_test.py
@@ -1,0 +1,313 @@
+from datetime import datetime
+import sys
+import glob
+import os
+import shutil
+import subprocess
+import filecmp
+import itertools
+
+import numpy as np
+
+from cabauw_input import create_case_input
+import microhh_tools as mht
+
+def clean_dir(path):
+    files = glob.glob(f'{path}/*')
+    for f in files:
+        os.remove(f)
+
+
+def execute(cmd, silent=True):
+    if silent:
+        return subprocess.call(cmd, shell=True, executable='/bin/bash', stdout=subprocess.DEVNULL, stderr=subprocess.STDOUT)
+    else:
+        return subprocess.call(cmd, shell=True, executable='/bin/bash')
+
+
+def test_restart(
+        architecture,
+        precision,
+        use_htessel = False,
+        use_rrtmgp = False,
+        use_homogeneous_z0 = True,
+        use_homogeneous_ls = True,
+        use_rt = False,
+        use_aerosols = False,
+        use_tdep_aerosols = False,
+        use_tdep_gasses = False,
+        use_tdep_background = False,
+        sw_micro = '0'):
+
+    executable = f'../../build_{precision}_{architecture}/microhh'
+    name = f'build_{precision}_{architecture}'
+    TF = np.float32 if precision=='sp' else np.float64
+
+    print(f'Testing {name:>16s}, htessel={use_htessel:1}, rrtmgp={use_rrtmgp:1}, rt={use_rt:1}, homog_z0={use_homogeneous_z0:1} homog_ls={use_homogeneous_ls:1}, aerosols={use_aerosols:1}, tdep_aer={use_tdep_aerosols:1}, tdep_gas={use_tdep_gasses:1}, tdep_bg={use_tdep_background:1}', end='')
+
+    itot = 4
+    jtot = 4
+    ktot = 128
+
+    xsize = itot*50
+    ysize = jtot*50
+    zsize = 4000
+
+    # NOTE: end_date is ignored for short restart test.
+    start_date = datetime(year=2016, month=8, day=15, hour=12)
+    end_date   = datetime(year=2016, month=8, day=15, hour=18)
+
+    # Restart frequency. Case will run for 2 x restart_freq.
+    restart_freq = 60
+
+    gpt_set = '128_112'
+
+    """
+    Create (long..) list of restart files.
+    """
+    restart_files = [
+            'thl', 'qt', 'u', 'v', 'w',
+            'dudz_mo', 'dvdz_mo', 'dbdz_mo',
+            'thermo_basestate', 'time']
+
+    if sw_micro == '2mom_warm':
+        restart_files += ['qr', 'nr']
+    elif sw_micro == 'nsw6':
+        restart_files += ['qr', 'qs', 'qg']
+
+    if use_htessel:
+        restart_files += ['wl_skin', 't_soil', 'theta_soil']
+
+    for thermo_var in ['thl', 'qt']:
+        restart_files.append(f'{thermo_var}_bot')
+
+        if use_htessel:
+            for tile in ['soil', 'veg', 'wet']:
+                restart_files.append(f'{thermo_var}_bot_{tile}')
+
+    if not use_htessel:
+        restart_files += ['thl_gradbot', 'qt_gradbot']
+
+        if sw_micro == '2mom_warm':
+            restart_files.append('qr_gradbot', 'nr_gradbot')
+        elif sw_micro == 'nsw6':
+            restart_files.append('qr_gradbot', 'qs_gradbot', 'qg_gradbot')
+
+    if not use_homogeneous_z0:
+        if use_htessel:
+            for tile in ['soil', 'veg', 'wet']:
+                restart_files.append(f'obuk_{tile}')
+        else:
+            restart_files.append('obuk')
+
+
+    """
+    Cleanup old files and create new input.
+    """
+    to_rm = glob.glob('*00*')
+    to_rm += glob.glob('*.txt')
+    to_rm += glob.glob('*.bin')
+    to_rm += ['cabauw.ini', 'cabauw_input.nc', 'stderr.log', 'stdout.log']
+
+    for f in to_rm:
+        if os.path.exists(f):
+            os.remove(f)
+
+    create_case_input(
+            start_date,
+            end_date,
+            use_htessel,
+            use_rrtmgp,
+            use_rt,
+            use_aerosols,
+            use_tdep_aerosols,
+            use_tdep_gasses,
+            use_tdep_background,
+            use_homogeneous_z0,
+            use_homogeneous_ls,
+            gpt_set,
+            sw_micro,
+            itot, jtot, ktot,
+            xsize, ysize, zsize,
+            TF)
+
+
+    """
+    Modify case for restart test.
+    """
+    ini = mht.Read_namelist('cabauw.ini')
+
+    ini['time']['savetime'] = restart_freq
+    ini['time']['endtime'] = restart_freq*2
+    ini['cross']['swcross'] = False
+
+    ini.save('cabauw.ini', allow_overwrite=True)
+
+
+    """
+    Run cold start.
+    """
+    ret = 0
+    ret += execute(f'{executable} init cabauw', silent)
+    ret += execute(f'{executable} run cabauw', silent)
+
+    if ret > 0:
+        print('\n')
+        raise Exception('ERROR: cold start failed!')
+
+    # Backup restart files from end of run.
+    if not os.path.exists('restart_files'):
+        os.makedirs('restart_files')
+    else:
+        clean_dir('restart_files')
+
+    time_str = f'{2*restart_freq:07d}'
+    for var in restart_files:
+        shutil.move(f'{var}.{time_str}', f'restart_files/{var}.{time_str}')
+
+    # DEBUG: binary dumps
+    files = glob.glob('*.bin')
+    for f in files:
+        shutil.move(f, 'restart_files')
+
+    """
+    Run warm start.
+    """
+    ini = mht.Read_namelist('cabauw.ini')
+
+    ini['time']['starttime'] = restart_freq
+    ini['cross']['swcross'] = False
+
+    ini.save('cabauw.ini', allow_overwrite=True)
+
+    ret = 0
+    ret += execute(f'{executable} run cabauw', silent)
+
+    if ret > 0:
+        print('\n')
+        raise Exception('ERROR: warm start failed!')
+
+
+    """
+    Compare restart files.
+    """
+    err = 0
+    for var in restart_files:
+
+        f1 = f'{var}.{time_str}'
+        f2 = f'restart_files/{var}.{time_str}'
+
+        the_same = filecmp.cmp(f1, f2)
+
+        if not the_same:
+            err += 1
+
+    if err == 0:
+        print(f' -> OKAY!')
+    else:
+        print(f' -> ERROR: {err}/{len(restart_files)} files not identical!')
+
+
+def test_permutations(
+        archictecture_opts,
+        precision_opts,
+        htessel_opts = [False],
+        rrtmgp_opts = [False],
+        homogeneous_z0_opts = [True],
+        homogeneous_ls_opts = [True],
+        rt_opts = [False],
+        aerosols_opts = [False],
+        tdep_aerosols_opts = [False],
+        tdep_gasses_opts = [False],
+        tdep_background_opts = [False]):
+
+    # Yes, this is not dangerous at all...
+    arg_dict = locals()
+    opts = list(arg_dict.values())
+    permutations = itertools.product(*opts)
+
+    for permutation in permutations:
+        test_restart(
+            permutation[0],
+            permutation[1],
+            permutation[2],
+            permutation[3],
+            permutation[4],
+            permutation[5],
+            permutation[6],
+            permutation[7],
+            permutation[8],
+            permutation[9],
+            permutation[10],
+            sw_micro='0')
+
+
+def test_base():
+    print('--- Testing base case with radiation and land-surface ---')
+
+    test_permutations(
+            archictecture_opts = ['gpu', 'gpu_kl', 'cpu', 'cpumpi'],
+            precision_opts = ['sp', 'dp'],
+            htessel_opts = [True, False],
+            rrtmgp_opts = [True, False])
+
+
+def test_heterogeneous_surface():
+    print('--- Testing heterogeneous land-surface options ---')
+
+    test_permutations(
+            archictecture_opts = ['gpu', 'cpu'],
+            precision_opts = ['sp'],
+            htessel_opts = [True, False],
+            rrtmgp_opts = [False],
+            homogeneous_z0_opts = [True, False],
+            homogeneous_ls_opts = [True, False])
+
+
+def test_aerosols_and_bg():
+    print('--- Testing aerosols and time varying background ---')
+
+    test_permutations(
+            archictecture_opts = ['gpu', 'cpu'],
+            precision_opts = ['sp'],
+            htessel_opts = [False],
+            rrtmgp_opts = [True],
+            aerosols_opts = [True, False],
+            tdep_aerosols_opts = [True, False])
+
+    test_permutations(
+            archictecture_opts = ['gpu', 'cpu'],
+            precision_opts = ['sp'],
+            htessel_opts = [False],
+            rrtmgp_opts = [True],
+            tdep_gasses_opts = [True, False],
+            tdep_background_opts = [True, False])
+
+
+def test_rt():
+    print('--- Testing ray tracer ---')
+
+    test_permutations(
+            archictecture_opts = ['gpu'],
+            precision_opts = ['sp'],
+            htessel_opts = [True, False],
+            rrtmgp_opts = [True],
+            rt_opts = [True],
+            aerosols_opts = [True, False])
+
+
+if __name__ == '__main__':
+
+    silent = True   # Suppress MicroHH stdout/err.
+
+    test_base()
+    test_heterogeneous_surface()
+    test_aerosols_and_bg()
+    test_rt()
+
+    #test_restart('cpu', 'sp', use_htessel=False, use_rrtmgp=False, use_homogeneous_z0=False)
+    #test_restart('cpu', 'sp', use_htessel=True, use_rrtmgp=False, use_homogeneous_z0=False)
+
+    #test_restart('gpu', 'sp', use_htessel=False, use_rrtmgp=True, use_rt=True)
+    #test_restart('gpu', 'sp', use_htessel=True, use_rrtmgp=True, use_rt=False)
+    #test_restart('gpu', 'sp', use_htessel=True, use_rrtmgp=True, use_rt=True)

--- a/cases/cabauw/cabauw_restart_test.py
+++ b/cases/cabauw/cabauw_restart_test.py
@@ -29,6 +29,7 @@ def test_restart(
         architecture,
         precision,
         use_htessel = False,
+        use_ags = False,
         use_rrtmgp = False,
         use_homogeneous_z0 = True,
         use_homogeneous_ls = True,
@@ -43,7 +44,7 @@ def test_restart(
     name = f'build_{precision}_{architecture}'
     TF = np.float32 if precision=='sp' else np.float64
 
-    print(f'Testing {name:>16s}, htessel={use_htessel:1}, rrtmgp={use_rrtmgp:1}, rt={use_rt:1}, homog_z0={use_homogeneous_z0:1} homog_ls={use_homogeneous_ls:1}, aerosols={use_aerosols:1}, tdep_aer={use_tdep_aerosols:1}, tdep_gas={use_tdep_gasses:1}, tdep_bg={use_tdep_background:1}', end='')
+    print(f'Testing {name:>16s}, htessel={use_htessel:1}, ags={use_ags:1}, rrtmgp={use_rrtmgp:1}, rt={use_rt:1}, homog_z0={use_homogeneous_z0:1} homog_ls={use_homogeneous_ls:1}, aerosols={use_aerosols:1}, tdep_aer={use_tdep_aerosols:1}, tdep_gas={use_tdep_gasses:1}, tdep_bg={use_tdep_background:1}', end='')
 
     itot = 4
     jtot = 4
@@ -70,6 +71,9 @@ def test_restart(
             'dudz_mo', 'dvdz_mo', 'dbdz_mo',
             'thermo_basestate', 'time']
 
+    if use_ags:
+        restart_files += ['co2']
+
     if sw_micro == '2mom_warm':
         restart_files += ['qr', 'nr']
     elif sw_micro == 'nsw6':
@@ -94,11 +98,7 @@ def test_restart(
             restart_files.append('qr_gradbot', 'qs_gradbot', 'qg_gradbot')
 
     if not use_homogeneous_z0:
-        if use_htessel:
-            for tile in ['soil', 'veg', 'wet']:
-                restart_files.append(f'obuk_{tile}')
-        else:
-            restart_files.append('obuk')
+        restart_files.append('obuk')
 
 
     """
@@ -117,6 +117,7 @@ def test_restart(
             start_date,
             end_date,
             use_htessel,
+            use_ags,
             use_rrtmgp,
             use_rt,
             use_aerosols,
@@ -212,6 +213,7 @@ def test_permutations(
         archictecture_opts,
         precision_opts,
         htessel_opts = [False],
+        ags_opts = [False],
         rrtmgp_opts = [False],
         homogeneous_z0_opts = [True],
         homogeneous_ls_opts = [True],
@@ -239,6 +241,7 @@ def test_permutations(
             permutation[8],
             permutation[9],
             permutation[10],
+            permutation[11],
             sw_micro='0')
 
 
@@ -250,6 +253,17 @@ def test_base():
             precision_opts = ['sp', 'dp'],
             htessel_opts = [True, False],
             rrtmgp_opts = [True, False])
+
+
+def test_ags():
+    print('--- Testing heterogeneous land-surface options ---')
+
+    test_permutations(
+            archictecture_opts = ['gpu', 'cpu', 'cpumpi'],
+            precision_opts = ['sp', 'dp'],
+            htessel_opts = [True],
+            ags_opts = [True],
+            rrtmgp_opts = [True])
 
 
 def test_heterogeneous_surface():
@@ -301,6 +315,7 @@ if __name__ == '__main__':
     silent = True   # Suppress MicroHH stdout/err.
 
     test_base()
+    #test_ags()
     test_heterogeneous_surface()
     test_aerosols_and_bg()
     test_rt()

--- a/cases/run_restart_set.py
+++ b/cases/run_restart_set.py
@@ -11,6 +11,7 @@ import drycblles.drycblles_test as drycblles
 import bomex.bomex_test as bomex
 import rico.rico_test as rico
 import gabls1.gabls1_test as gabls1
+import arm.arm_test as arm
 
 modes = ['cpu', 'cpumpi', 'gpu']
 precs = ['dp', 'sp']
@@ -65,3 +66,8 @@ for prec in precs:
         mht.run_restart('rico',
                 rico.opt_small, rico.opt_mpi, rico.dict_opts,
                microhh_exec, mode, 'rico', experiment)
+
+        # ARM LES intercomparison
+        mht.run_restart('arm',
+                arm.opt_small, arm.opt_mpi, arm.dict_opts,
+               microhh_exec, mode, 'arm', experiment)

--- a/include/boundary_surface_lsm.h
+++ b/include/boundary_surface_lsm.h
@@ -198,9 +198,6 @@ class Boundary_surface_lsm : public Boundary<TF>
         std::vector<TF> infiltration;    // Infiltration moisture into soil (m s-1)
         std::vector<TF> runoff;          // Surface runoff from soil (m s-1)
 
-        std::vector<TF> an_co2;          // CO2 assimilation (photosynthesis).
-        std::vector<TF> resp_co2;        // CO2 respiration from soil.
-
         // Soil properties
         std::vector<int> soil_index;     // Index in lookup tables
         std::vector<TF> diffusivity;     // Full level (m2 s-1)
@@ -224,6 +221,10 @@ class Boundary_surface_lsm : public Boundary<TF>
         // Soil respiration properties.
         std::vector<TF> r10;             // Soil respiration at 10 deg C (mgCO2 m-2 s-1)
         std::vector<TF> ea;              // Activation energy (K)
+
+        // Surface fluxes CO2.
+        std::vector<TF> an_co2;          // CO2 assimilation (photosynthesis).
+        std::vector<TF> resp_co2;        // CO2 respiration from soil.
 
         // Lookup table data obtained from input van Genuchten NetCDF file:
         std::vector<TF> theta_res;       // Residual soil moisture content (m3 m-3)
@@ -277,19 +278,38 @@ class Boundary_surface_lsm : public Boundary<TF>
         int* water_mask_g;     // Mask for open water (-)
         TF* t_bot_water_g;
 
-        TF* interception_g;   // Interception rain/dew by surface (m s-1)
-        TF* throughfall_g;    // Throughfall rain/dew onto soil (m s-1)
-        TF* infiltration_g;   // Infiltration moisture into soil (m s-1)
-        TF* runoff_g;         // Surface runoff from soil (m s-1)
+        TF* interception_g;    // Interception rain/dew by surface (m s-1)
+        TF* throughfall_g;     // Throughfall rain/dew onto soil (m s-1)
+        TF* infiltration_g;    // Infiltration moisture into soil (m s-1)
+        TF* runoff_g;          // Surface runoff from soil (m s-1)
 
         // Soil properties
-        int* soil_index_g;    // Index in lookup tables
-        TF* diffusivity_g;    // Full level (m2 s-1)
-        TF* diffusivity_h_g;  // Half level (m2 s-1)
-        TF* conductivity_g;   // Full level (unit m s-1)
-        TF* conductivity_h_g; // Half level (unit m s-1)
-        TF* source_g;         // Source term (unit s-1)
-        TF* root_fraction_g;  // Root fraction per soil layer (-)
+        int* soil_index_g;     // Index in lookup tables
+        TF* diffusivity_g;     // Full level (m2 s-1)
+        TF* diffusivity_h_g;   // Half level (m2 s-1)
+        TF* conductivity_g;    // Full level (unit m s-1)
+        TF* conductivity_h_g;  // Half level (unit m s-1)
+        TF* source_g;          // Source term (unit s-1)
+        TF* root_fraction_g;   // Root fraction per soil layer (-)
+
+        // A-Gs vegetation properties.
+        TF* alpha0_g;          // Lightuse efficiency at low light conditions (mgCO2 J-1 PAR)
+        TF* t1gm_g;            // Reference temperature calculation mesophyll conductance (K)
+        TF* t2gm_g;            // Reference temperature calculation mesophyll conductance (K)
+        TF* t1am_g;            // Reference temperature calculation max primary production (K)
+        TF* gm298_g;           // Mesophyl conductance at 298 K (mm s-1)
+        TF* gmin_g;            // Cuticular minimum conductance (m s-1)
+        TF* ammax298_g;        // CO2 maximal primary productivity (mgCO2 m-2 s-1)
+        TF* f0_g;              // Maximum value Cfrac (-)
+        TF* co2_comp298_g;     // CO2 compensation concentration at 298 K (ppm)
+
+        // Soil respiration properties.
+        TF* r10_g;             // Soil respiration at 10 deg C (mgCO2 m-2 s-1)
+        TF* ea_g;              // Activation energy (K)
+
+        // Surface fluxes CO2.
+        TF* an_co2_g;          // CO2 assimilation (photosynthesis).
+        TF* resp_co2_g;        // CO2 respiration from soil.
 
         // Lookup table data obtained from input NetCDF file:
         TF* theta_res_g;  // Residual soil moisture content (m3 m-3)

--- a/include/boundary_surface_lsm.h
+++ b/include/boundary_surface_lsm.h
@@ -54,13 +54,6 @@ struct Surface_tile
     TF* thl_bot_g;  // Skin (liquid water) potential temperature (K)
     TF* qt_bot_g;   // Skin specific humidity (kg kg-1)
 
-    // Surface layer
-    TF* obuk_g;     // Obukhov length (m)
-    TF* ustar_g;    // Friction velocity (m s-1)
-    TF* bfluxbot_g; // Friction velocity (m s-1)
-    int* nobuk_g;   // Index in LUT
-    TF* ra_g;       // Aerodynamic resistance (s m-1)
-
     // Land surface
     TF* rs_g;       // Surface resistance (canopy or soil, s m-1)
     TF* H_g;        // Sensible heat flux (W m-2)
@@ -255,6 +248,7 @@ class Boundary_surface_lsm : public Boundary<TF>
 
         TF* ustar_g;
         TF* obuk_g;
+        TF* ra_g;
 
         cuda_vector<TF> dudz_mo_g;
         cuda_vector<TF> dvdz_mo_g;

--- a/include/boundary_surface_lsm.h
+++ b/include/boundary_surface_lsm.h
@@ -200,8 +200,8 @@ class Boundary_surface_lsm : public Boundary<TF>
         std::vector<TF> runoff;         // Surface runoff from soil (m s-1)
 
         std::vector<int> ags_index;     // A-Gs vegetation index in lookup table.
-        std::vector<int> an_co2;        // CO2 assimilation (photosynthesis).
-        std::vector<int> resp_co2;      // CO2 respiration from soil.
+        std::vector<TF> an_co2;         // CO2 assimilation (photosynthesis).
+        std::vector<TF> resp_co2;       // CO2 respiration from soil.
 
         // Soil properties
         std::vector<int> soil_index;    // Index in lookup tables

--- a/include/boundary_surface_lsm.h
+++ b/include/boundary_surface_lsm.h
@@ -177,7 +177,6 @@ class Boundary_surface_lsm : public Boundary<TF>
 
         // Lookup tables van Genuchten parameterisation & A-Gs scheme.
         std::shared_ptr<Netcdf_file> nc_lookup_table_vg;
-        std::shared_ptr<Netcdf_file> nc_lookup_table_ags;
 
         // Soil cross-sections
         std::vector<std::string> crosslist;
@@ -192,57 +191,60 @@ class Boundary_surface_lsm : public Boundary<TF>
         std::vector<TF> lambda_unstable; // Skin conductivity unstable conditions (W m-2 K-1)
         std::vector<TF> cs_veg;          // Heat capacity skin layer (J K-1 m-2)
         std::vector<int> water_mask;     // Mask for open water (-)
-        std::vector<TF> t_bot_water;
+        std::vector<TF> t_bot_water;     // Skin temperature water (K)
 
-        std::vector<TF> interception;   // Interception rain/dew by surface (m s-1)
-        std::vector<TF> throughfall;    // Throughfall rain/dew onto soil (m s-1)
-        std::vector<TF> infiltration;   // Infiltration moisture into soil (m s-1)
-        std::vector<TF> runoff;         // Surface runoff from soil (m s-1)
+        std::vector<TF> interception;    // Interception rain/dew by surface (m s-1)
+        std::vector<TF> throughfall;     // Throughfall rain/dew onto soil (m s-1)
+        std::vector<TF> infiltration;    // Infiltration moisture into soil (m s-1)
+        std::vector<TF> runoff;          // Surface runoff from soil (m s-1)
 
-        std::vector<int> ags_index;     // A-Gs vegetation index in lookup table.
-        std::vector<TF> an_co2;         // CO2 assimilation (photosynthesis).
-        std::vector<TF> resp_co2;       // CO2 respiration from soil.
+        std::vector<TF> an_co2;          // CO2 assimilation (photosynthesis).
+        std::vector<TF> resp_co2;        // CO2 respiration from soil.
 
         // Soil properties
-        std::vector<int> soil_index;    // Index in lookup tables
-        std::vector<TF> diffusivity;    // Full level (m2 s-1)
-        std::vector<TF> diffusivity_h;  // Half level (m2 s-1)
-        std::vector<TF> conductivity;   // Full level (unit m s-1)
-        std::vector<TF> conductivity_h; // Half level (unit m s-1)
-        std::vector<TF> source;         // Source term (unit s-1)
-        std::vector<TF> root_fraction;  // Root fraction per soil layer (-)
+        std::vector<int> soil_index;     // Index in lookup tables
+        std::vector<TF> diffusivity;     // Full level (m2 s-1)
+        std::vector<TF> diffusivity_h;   // Half level (m2 s-1)
+        std::vector<TF> conductivity;    // Full level (unit m s-1)
+        std::vector<TF> conductivity_h;  // Half level (unit m s-1)
+        std::vector<TF> source;          // Source term (unit s-1)
+        std::vector<TF> root_fraction;   // Root fraction per soil layer (-)
+
+        // A-Gs vegetation properties.
+        std::vector<TF> alpha0;          // Lightuse efficiency at low light conditions (mgCO2 J-1 PAR)
+        std::vector<TF> t1gm;            // Reference temperature calculation mesophyll conductance (K)
+        std::vector<TF> t2gm;            // Reference temperature calculation mesophyll conductance (K)
+        std::vector<TF> t1am;            // Reference temperature calculation max primary production (K)
+        std::vector<TF> gm298;           // Mesophyl conductance at 298 K (mm s-1)
+        std::vector<TF> gmin;            // Cuticular minimum conductance (m s-1)
+        std::vector<TF> ammax298;        // CO2 maximal primary productivity (mgCO2 m-2 s-1)
+        std::vector<TF> f0;              // Maximum value Cfrac (-)
+        std::vector<TF> co2_comp298;     // CO2 compensation concentration at 298 K (ppm)
+
+        // Soil respiration properties.
+        std::vector<TF> r10;             // Soil respiration at 10 deg C (mgCO2 m-2 s-1)
+        std::vector<TF> ea;              // Activation energy (K)
 
         // Lookup table data obtained from input van Genuchten NetCDF file:
-        std::vector<TF> theta_res;  // Residual soil moisture content (m3 m-3)
-        std::vector<TF> theta_wp;   // Soil moisture content at wilting point (m3 m-3)
-        std::vector<TF> theta_fc;   // Soil moisture content at field capacity (m3 m-3)
-        std::vector<TF> theta_sat;  // Soil moisture content at saturation (m3 m-3)
+        std::vector<TF> theta_res;       // Residual soil moisture content (m3 m-3)
+        std::vector<TF> theta_wp;        // Soil moisture content at wilting point (m3 m-3)
+        std::vector<TF> theta_fc;        // Soil moisture content at field capacity (m3 m-3)
+        std::vector<TF> theta_sat;       // Soil moisture content at saturation (m3 m-3)
 
-        std::vector<TF> gamma_theta_sat;  // Conducticity soil moisture at saturation (m3 m-3)
+        std::vector<TF> gamma_theta_sat; // Conducticity soil moisture at saturation (m3 m-3)
 
-        std::vector<TF> vg_a;  // van Genuchten parameter alpha (m-1)
-        std::vector<TF> vg_l;  // van Genuchten parameter l (-)
-        std::vector<TF> vg_n;  // van Genuchten parameter n (-)
+        std::vector<TF> vg_a;            // van Genuchten parameter alpha (m-1)
+        std::vector<TF> vg_l;            // van Genuchten parameter l (-)
+        std::vector<TF> vg_n;            // van Genuchten parameter n (-)
 
         // Derived lookup table entries
-        std::vector<TF> vg_m;  // van Genuchten parameter m (-)
-
-        std::vector<TF> kappa_theta_max;  // Maximum diffusivity (m2 s-1)
-        std::vector<TF> kappa_theta_min;  // Minimum diffusivity (m2 s-1)
-        std::vector<TF> gamma_theta_max;  // Maximum conductivity (m s-1):
-        std::vector<TF> gamma_theta_min;  // Minimum conductivity (m s-1)
-        std::vector<TF> gamma_T_dry;      // Heat conductivity dry soil (m s-1)
-        std::vector<TF> rho_C;            // Volumetric soil heat capacity (J m-3 K-1)
-
-        // Lookup table data from input A-Gs NetCDF file.
-        std::vector<TF> alpha0;        // Lightuse efficiency at low light conditions
-        std::vector<TF> t2gm;          // Reference temperature calculation mesophyll conductance
-        std::vector<TF> r0;            // Soil respiration at 298 K?
-        std::vector<TF> gm298;         // Mesophyl conductance at 298 K
-        std::vector<TF> gmin;          // Cuticular minimum conductance
-        std::vector<TF> ammax298;      // CO2 maximal primary productivity
-        std::vector<TF> f0;            // Maximum value Cfrac
-        std::vector<TF> co2_comp298;   // CO2 compensation concentration at 298 K
+        std::vector<TF> vg_m;            // van Genuchten parameter m (-)
+        std::vector<TF> kappa_theta_max; // Maximum diffusivity (m2 s-1)
+        std::vector<TF> kappa_theta_min; // Minimum diffusivity (m2 s-1)
+        std::vector<TF> gamma_theta_max; // Maximum conductivity (m s-1):
+        std::vector<TF> gamma_theta_min; // Minimum conductivity (m s-1)
+        std::vector<TF> gamma_T_dry;     // Heat conductivity dry soil (m s-1)
+        std::vector<TF> rho_C;           // Volumetric soil heat capacity (J m-3 K-1)
 
         #ifdef USECUDA
         void print_ij(const TF*);

--- a/include/boundary_surface_lsm.h
+++ b/include/boundary_surface_lsm.h
@@ -41,13 +41,6 @@ struct Surface_tile
     std::vector<TF> thl_bot;  // Skin (liquid water) potential temperature (K)
     std::vector<TF> qt_bot;   // Skin specific humidity (kg kg-1)
 
-    // Surface layer
-    std::vector<TF> obuk;     // Obukhov length (m)
-    std::vector<TF> ustar;    // Friction velocity (m s-1)
-    std::vector<TF> bfluxbot; // Friction velocity (m s-1)
-    std::vector<int> nobuk;   // Index in LUT
-    std::vector<TF> ra;       // Aerodynamic resistance (s m-1)
-
     // Land surface
     std::vector<TF> rs;       // Surface resistance (canopy or soil, s m-1)
     std::vector<TF> H;        // Sensible heat flux (W m-2)
@@ -170,6 +163,7 @@ class Boundary_surface_lsm : public Boundary<TF>
 
         std::vector<TF> ustar;
         std::vector<TF> obuk;
+        std::vector<TF> ra;
 
         std::vector<TF> dudz_mo;
         std::vector<TF> dvdz_mo;

--- a/include/boundary_surface_lsm.h
+++ b/include/boundary_surface_lsm.h
@@ -154,6 +154,7 @@ class Boundary_surface_lsm : public Boundary<TF>
         bool sw_tile_stats;
         bool sw_tile_stats_col;
         bool sw_homogenize_sfc;
+        bool sw_ags;
 
         TF emis_sfc;
 
@@ -174,8 +175,9 @@ class Boundary_surface_lsm : public Boundary<TF>
         std::vector<TF> dvdz_mo;
         std::vector<TF> dbdz_mo;
 
-        // Lookup tables van Genuchten parameterisation
-        std::shared_ptr<Netcdf_file> nc_lookup_table;
+        // Lookup tables van Genuchten parameterisation & A-Gs scheme.
+        std::shared_ptr<Netcdf_file> nc_lookup_table_vg;
+        std::shared_ptr<Netcdf_file> nc_lookup_table_ags;
 
         // Soil cross-sections
         std::vector<std::string> crosslist;
@@ -197,6 +199,10 @@ class Boundary_surface_lsm : public Boundary<TF>
         std::vector<TF> infiltration;   // Infiltration moisture into soil (m s-1)
         std::vector<TF> runoff;         // Surface runoff from soil (m s-1)
 
+        std::vector<int> ags_index;     // A-Gs vegetation index in lookup table.
+        std::vector<int> an_co2;        // CO2 assimilation (photosynthesis).
+        std::vector<int> resp_co2;      // CO2 respiration from soil.
+
         // Soil properties
         std::vector<int> soil_index;    // Index in lookup tables
         std::vector<TF> diffusivity;    // Full level (m2 s-1)
@@ -206,7 +212,7 @@ class Boundary_surface_lsm : public Boundary<TF>
         std::vector<TF> source;         // Source term (unit s-1)
         std::vector<TF> root_fraction;  // Root fraction per soil layer (-)
 
-        // Lookup table data obtained from input NetCDF file:
+        // Lookup table data obtained from input van Genuchten NetCDF file:
         std::vector<TF> theta_res;  // Residual soil moisture content (m3 m-3)
         std::vector<TF> theta_wp;   // Soil moisture content at wilting point (m3 m-3)
         std::vector<TF> theta_fc;   // Soil moisture content at field capacity (m3 m-3)
@@ -227,6 +233,16 @@ class Boundary_surface_lsm : public Boundary<TF>
         std::vector<TF> gamma_theta_min;  // Minimum conductivity (m s-1)
         std::vector<TF> gamma_T_dry;      // Heat conductivity dry soil (m s-1)
         std::vector<TF> rho_C;            // Volumetric soil heat capacity (J m-3 K-1)
+
+        // Lookup table data from input A-Gs NetCDF file.
+        std::vector<TF> alpha0;        // Lightuse efficiency at low light conditions
+        std::vector<TF> t2gm;          // Reference temperature calculation mesophyll conductance
+        std::vector<TF> r0;            // Soil respiration at 298 K?
+        std::vector<TF> gm298;         // Mesophyl conductance at 298 K
+        std::vector<TF> gmin;          // Cuticular minimum conductance
+        std::vector<TF> ammax298;      // CO2 maximal primary productivity
+        std::vector<TF> f0;            // Maximum value Cfrac
+        std::vector<TF> co2_comp298;   // CO2 compensation concentration at 298 K
 
         #ifdef USECUDA
         void print_ij(const TF*);

--- a/include/constants.h
+++ b/include/constants.h
@@ -42,7 +42,8 @@ namespace Constants
     template<typename TF> constexpr TF mu0_min = 1e-6;        // Minimum value used for cos(sza)
     template<typename TF> constexpr TF sigma_b = 5.67e-8;     // Boltzmann constant [W m-1 K-1]
     template<typename TF> constexpr TF xmair = 28.9647;       // Molar mass of dry air [kg kmol-1]
-    template<typename TF> constexpr TF xmh2o = 18.01528;      // Molar mass of h2o [kg kmol-1]
+    template<typename TF> constexpr TF xmh2o = 18.01528;      // Molar mass of H2O [kg kmol-1]
+    template<typename TF> constexpr TF xmco2 = 44.009;        // Molar mass of CO2 [kg kmol-1]
 
     // Soil / land-surface specific constants
     template<typename TF> constexpr TF rho_C_matrix   = 1.6e6;   // Volumetric soil heat capacity [J m-3 K-1]

--- a/include/land_surface_kernels.h
+++ b/include/land_surface_kernels.h
@@ -230,7 +230,7 @@ namespace Land_surface_kernels
     template<typename TF>
     void calc_canopy_resistance_ags(
             TF* const restrict rs,
-            TF* const restrict rs_co2,
+            TF* const restrict an_co2,
             const TF* const restrict lai,
             const TF* const restrict t_bot,
             const TF* const restrict ra,
@@ -239,7 +239,7 @@ namespace Land_surface_kernels
             const TF* const restrict qt,
             const TF* const restrict sw_flux_dn,
             const TF* const restrict theta_rel_mean,
-            const TF* const restrict albedo,
+            //const TF* const restrict albedo,
             const TF* const restrict vpds,
             const int* const restrict ags_index,
             // Vegetation specific constants:
@@ -448,13 +448,14 @@ namespace Land_surface_kernels
                 //    gcco2 = gc_inf
                 const TF gcco2 = gc_inf;
 
-                // Surface resistances for moisture and carbon dioxide
+                // Output values from kernel:
+                // Surface resistances for moisture.
                 rs[ij] = TF(1) / (TF(1.6) * gcco2);
-                rs_co2[ij] = TF(1) / gcco2;
 
                 // Net flux of CO2 into the plant (An)
                 // co2_abs has units kg(CO2)/m3(air), so flux is in kg(co2)/m2/s.
-                an[ij] = -(co2_abs - ci) / (ra[ij] + rs_co2[ij]);
+                const TF rs_co2 = TF(1) / gcco2;
+                an_co2[ij] = -(co2_abs - ci) / (ra[ij] + rs_co2[ij]);
             }
     }
 

--- a/include/land_surface_kernels.h
+++ b/include/land_surface_kernels.h
@@ -471,6 +471,29 @@ namespace Land_surface_kernels
 
 
     template<typename TF>
+    void calc_soil_respiration_jacobs(
+            TF* const restrict resp_co2,
+            const TF* const restrict t_soil_mean,
+            const TF* const restrict r10,
+            const TF* const restrict ea,
+            const TF rho_bot,
+            const int istart, const int iend,
+            const int jstart, const int jend,
+            const int jstride)
+    {
+        const TF to_mol  = Constants::xmair<TF> / Constants::xmco2<TF> * TF(1e-6) * rho_bot;
+
+        for (int j=jstart; j<jend; ++j)
+            #pragma ivdep
+            for (int i=istart; i<iend; ++i)
+            {
+                const int ij  = i + j*jstride;
+                resp_co2[ij] = r10[ij] * std::exp(ea[ij] / (TF(283.15) * TF(8.314)) * (TF(1) - TF(283.15) / t_soil_mean[ij])) * to_mol;
+            }
+    }
+
+
+    template<typename TF>
     void calc_soil_resistance(
             TF* const restrict rs,
             const TF* const restrict rs_min,

--- a/include/land_surface_kernels.h
+++ b/include/land_surface_kernels.h
@@ -47,12 +47,6 @@ namespace Land_surface_kernels
         tile.thl_bot.resize(ijcells);
         tile.qt_bot.resize(ijcells);
 
-        tile.obuk.resize(ijcells);
-        tile.ustar.resize(ijcells);
-        tile.bfluxbot.resize(ijcells);
-        tile.nobuk.resize(ijcells);
-        tile.ra.resize(ijcells);
-
         tile.rs.resize(ijcells);
         tile.H.resize(ijcells);
         tile.LE.resize(ijcells);

--- a/include/land_surface_kernels.h
+++ b/include/land_surface_kernels.h
@@ -316,7 +316,7 @@ namespace Land_surface_kernels
                 // Calculate CO2 concentration inside the leaf (ci).
                 // NOTE: Differs from IFS
                 const TF fmin0 = gmin[ij] / nuco2q - TF(1./9.) * gm;
-                const TF fmin = std::pow(-fmin0 + (fm::pow2(fmin0) + TF(4) * gmin[ij] / nuco2q * gm), TF(0.5)) / (TF(2) * gm);
+                const TF fmin = std::pow(std::max(-fmin0 + (fm::pow2(fmin0) + TF(4) * gmin[ij] / nuco2q * gm), TF(Constants::dsmall)), TF(0.5)) / (TF(2) * gm);
 
                 // Calculate atmospheric moisture deficit.
                 // "Therefore Ci/Cs is specified as a function of atmospheric moisture deficit Ds at the leaf surface".
@@ -465,6 +465,7 @@ namespace Land_surface_kernels
                 // `co2_abs` has units [mg(CO2) m-3(air)], so flux has units [mg(CO2) m-2 s-1)].
                 // Conversion with `to_mol` results in flux in [kmol(CO2) kmol-1(air) m s-1].
                 an_co2[ij] = (ci - co2_abs) / (ra[ij] + (TF(1) / gcco2)) * to_mol;
+
 
                 if (std::isnan(rs[ij]))
                     throw std::runtime_error("Canopy resistance contains NaNs!");

--- a/include/land_surface_kernels.h
+++ b/include/land_surface_kernels.h
@@ -267,7 +267,6 @@ namespace Land_surface_kernels
             //const TF cos_sza,
             const TF rho,
             const TF rho_bot,
-            const TF p_bot,
             const bool sw_splitleaf,
             const int istart, const int iend,
             const int jstart, const int jend,

--- a/include/land_surface_kernels_gpu.h
+++ b/include/land_surface_kernels_gpu.h
@@ -447,6 +447,30 @@ namespace Land_surface_kernels_g
 
 
     template<typename TF> __global__
+    void calc_soil_respiration_jacobs_g(
+            TF* const restrict resp_co2,
+            const TF* const restrict t_soil_mean,
+            const TF* const restrict r10,
+            const TF* const restrict ea,
+            const TF rho_bot,
+            const int istart, const int iend,
+            const int jstart, const int jend,
+            const int jstride)
+    {
+        const TF to_mol  = Constants::xmair<TF> / Constants::xmco2<TF> * TF(1e-6) * rho_bot;
+
+        const int i = blockIdx.x*blockDim.x + threadIdx.x + istart;
+        const int j = blockIdx.y*blockDim.y + threadIdx.y + jstart;
+
+        if (i < iend && j < jend)
+        {
+            const int ij  = i + j*jstride;
+            resp_co2[ij] = r10[ij] * exp(ea[ij] / (TF(283.15) * TF(8.314)) * (TF(1) - TF(283.15) / t_soil_mean[ij])) * to_mol;
+        }
+    }
+
+
+    template<typename TF> __global__
     void calc_soil_resistance_g(
             TF* const __restrict__ rs,
             const TF* const __restrict__ rs_min,

--- a/include/land_surface_kernels_gpu.h
+++ b/include/land_surface_kernels_gpu.h
@@ -203,6 +203,249 @@ namespace Land_surface_kernels_g
         }
     }
 
+
+    template<typename TF> __device__
+    inline TF e1_approx_g(const TF x)
+    {
+        // E1() approximation, from: https://doi.org/10.1016/S0022-1694(99)00184-5
+        const TF euler = TF(0.5772156649015329);
+        const TF G = exp(-euler);
+        const TF b = pow(TF(2) * ((TF(1) - G) / (G * (TF(2) - G))), TF(0.5));
+        const TF h_inf = (TF(1) - G) * (fm::pow2(G) - TF(6) * G + TF(12)) / (TF(3) * G * fm::pow2(TF(2) - G) * b);
+        const TF q = TF(20/47.) * pow(x, pow(TF(31/26.), TF(0.5)));
+        const TF h = TF(1) / (TF(1) + x * pow(x, TF(0.5)));
+        const TF E1 = exp(-x) / (G + (TF(1) - G) * exp(-x / (TF(1) - G))) * log(TF(1) + G / x - (TF(1) - G) / fm::pow2(h + b * x));
+        return E1;
+    }
+
+
+    template<typename TF> __global__
+    void calc_canopy_resistance_ags_g(
+            TF* const restrict rs,
+            TF* const restrict an_co2,
+            const TF* const restrict lai,
+            const TF* const restrict t_bot,
+            const TF* const restrict ra,
+            const TF* const restrict co2,
+            const TF* const restrict thl,
+            const TF* const restrict qt,
+            const TF* const restrict sw_flux_dn,
+            const TF* const restrict theta_rel_mean,
+            //const TF* const restrict albedo,
+            const TF* const restrict vpds,
+            const TF* const restrict alpha0,
+            const TF* const restrict t1gm,
+            const TF* const restrict t2gm,
+            const TF* const restrict t1am,
+            const TF* const restrict gm298,
+            const TF* const restrict gmin,
+            const TF* const restrict ammax298,
+            const TF* const restrict f0,
+            const TF* const restrict co2_comp298,
+            //const TF cos_sza,
+            const TF rho,
+            const TF rho_bot,
+            const bool sw_splitleaf,
+            const int istart, const int iend,
+            const int jstart, const int jend,
+            const int kstart,
+            const int jstride,
+            const int kstride)
+    {
+        const int i = blockIdx.x*blockDim.x + threadIdx.x + istart;
+        const int j = blockIdx.y*blockDim.y + threadIdx.y + jstart;
+
+        if (i < iend && j < jend)
+        {
+            const int ij  = i + j*jstride;
+            const int ijk = ij + kstart*kstride;
+
+            // Fixed constants.
+            const TF q10gm = TF(2);      // Parameter to calculate the mesophyll conductance
+            const TF q10am = TF(2);      // Parameter to calculate max primary productivity
+            const TF q10lambda = TF(1);  // Parameter to calculate the CO2 compensation concentration. (2 in IFS, 1.5 in DALES)
+
+            const TF t2am = TF(311);     // Reference temperatures calculation max primary productivity [K]
+
+            const TF nuco2q = TF(1.6);   // Ratio molecular viscosity water to carbon dioxide [-]
+            const TF ad = TF(0.07);      // Regression coefficient to calculate Cfrac [kPa-1]
+            const TF kx = TF(0.7);       // Extinction coefficient PAR in canopy [m_ground m_leaf-1]
+
+            // For sw_splitleaf.
+            //nr_gauss = 3                                   # Amount of bins to use for Gaussian integrations
+            //weight_g = np.array([0.2778, 0.4444, 0.2778])  # Weights of the Gaussian bins (must add up to 1)
+            //angle_g  = np.array([0.1127,    0.5, 0.8873])  # Sines of the leaf angles compared to the sun in the first Gaussian integration
+            //angle_weight_sum = np.sum(weight_g * angle_g)
+            //LAI_g    = np.array([0.1127,    0.5, 0.8873])  # Ratio of integrated LAI at locations where shaded leaves are evaluated in the second Gaussian integration
+            //sigma    = 0.2                                 # Scattering coefficient
+            //kdfbl    = 0.8                                 # Diffuse radiation extinction coefficient for black leaves
+
+            // Fixed conversion factors.
+            const TF to_mgm3 = Constants::xmco2<TF> / Constants::xmair<TF> * TF(1e6) * rho;
+            const TF to_mol  = Constants::xmair<TF> / Constants::xmco2<TF> * TF(1e-6) * rho_bot;
+
+            // Calculate the CO2 compensation concentration (IFS eq. 8.92).
+            // "The compensation point Γ is defined as the CO2 concentration at which the net CO2 assimilation of a fully lit leaf becomes zero".
+            const TF co2_comp = rho_bot * co2_comp298[ij] * pow(q10lambda, TF(0.1) * (t_bot[ij] - TF(298)));
+
+            // Calculate the mesophyll conductance (IFS eq. 8.93).
+            // "The mesophyll conductance gm describes the transport of CO2 from the substomatal cavities to the mesophyll cells where the carbon is fixed".
+            const TF gm = gm298[ij] * pow(q10gm, TF(0.1) * (t_bot[ij] - TF(298))) / ((TF(1) + exp(TF(0.3) * (t1gm[ij] - t_bot[ij]))) * (TF(1) + exp(TF(0.3) * (t_bot[ij] - t2gm[ij])))) / TF(1000);
+
+            // Calculate CO2 concentration inside the leaf (ci).
+            // NOTE: Differs from IFS
+            const TF fmin0 = gmin[ij] / nuco2q - TF(1./9.) * gm;
+            const TF fmin = pow(-fmin0 + (fm::pow2(fmin0) + TF(4) * gmin[ij] / nuco2q * gm), TF(0.5)) / (TF(2) * gm);
+
+            // Calculate atmospheric moisture deficit.
+            // "Therefore Ci/Cs is specified as a function of atmospheric moisture deficit Ds at the leaf surface".
+            // Based on other literature, I think this indeed has to be the "leaf to air VPD", so esat(Ts) - e(Ta).
+            const TF ds = vpds[ij] / 1000.;
+
+            // This seems to differ from IFS?
+            const TF dmax = (f0[ij] - fmin) / ad;
+
+            // Coupling factor (IFS eq. 8.101).
+            const TF cfrac = max(TF(0.01), f0[ij] * (TF(1) - ds / dmax) + fmin * (ds / dmax));
+
+            // Absolute CO2 concentration. Input = [mol(CO2) mol-1(air)], co2_abs = [mg(CO2) m-3(air)].
+            const TF co2_abs  = co2[ijk] * to_mgm3;
+
+            // CO2 concentration in leaf (IFS eq. ???).
+            //if (lrelaxci) then
+            //  if (ci_old_set) then
+            //    ci_inf        = cfrac * (co2_abs - co2_comp) + co2_comp
+            //    ci            = ci_old(i,j) + min(kci*rk3coef, 1.0) * (ci_inf - ci_old(i,j))
+            //    if (rk3step  == 3) then
+            //      ci_old(i,j) = ci
+            //    endif
+            //  else
+            //    ci            = cfrac * (co2_abs - co2_comp) + co2_comp
+            //    ci_old(i,j)   = ci
+            //  endif
+            //else
+            const TF ci = cfrac * (co2_abs - co2_comp) + co2_comp;
+            //endif
+
+            // Max gross primary production in high light conditions (Ag) (IFS eq. 8.94).
+            const TF ammax = ammax298[ij] * pow(q10am, TF(0.1) * (t_bot[ij] - TF(298))) / ((TF(1) + exp(TF(0.3) * (t1am[ij] - t_bot[ij]))) * (TF(1) + exp(TF(0.3) * (t_bot[ij] - t2am))));
+
+            // Effect of soil moisture stress on gross assimilation rate.
+            // NOTE: this seems to be different in IFS...
+            const TF fstr = max(TF(1e-3), min(TF(1), theta_rel_mean[ij]));
+
+            // Gross assimilation rate (Am, IFS eq. 8.97).
+            const TF am = ammax * (TF(1) - exp(-(gm * (ci - co2_comp) / ammax)));
+
+            // Autotrophic dark respiration (IFS eq. 8.99).
+            const TF rdark = am / TF(9);
+
+            // Photosynthetically active radiation [W m-2].
+            const TF par = TF(0.5) * max(TF(0.1), sw_flux_dn[ij]);
+
+            // Light use efficiency.
+            const TF alphac = alpha0[ij] * (co2_abs - co2_comp) / (co2_abs + 2 * co2_comp);
+
+            TF an, gc_inf;
+            //if (sw_splitleaf)
+            //{
+            //    PARdir   = 0.5 * max(0.1, sw_in[j,i])
+            //    PARdif   = 0.5 * max(0.1, sw_in[j,i])
+            //    cos_sza  = max(1e-10, cos_sza)
+
+            //    kdrbl = 0.5 / cos_sza   # Direct radiation extinction coefficient for black leaves
+            //    kdf = kdfbl * np.sqrt(1.0 - sigma)
+            //    kdr = kdrbl * np.sqrt(1.0 - sigma)
+            //    ref = (1.0 - np.sqrt(1.0 - sigma)) / (1.0 + np.sqrt(1.0 - sigma)) # Reflection coefficient
+            //    ref_dir = 2 * ref / (1.0 + 1.6 * cos_sza)
+
+            //    Hleaf = np.zeros(nr_gauss+1)
+            //    Fleaf = np.zeros(nr_gauss+1)
+            //    Agl   = np.zeros(nr_gauss+1)
+
+            //    Fnet  = np.zeros(nr_gauss)
+            //    gnet  = np.zeros(nr_gauss)
+
+            //    # Loop over different LAI locations
+            //    for it in range(nr_gauss):
+
+            //        iLAI = LAI[j,i] * LAI_g[it]   # Integrated LAI between here and canopy top; Gaussian distributed
+            //        fSL = np.exp(-kdrbl * iLAI)  # Fraction of sun-lit leaves
+
+            //        PARdfD = PARdif * (1.0-ref)     * np.exp(-kdf * iLAI)             # Total downward PAR due to diffuse radiation at canopy top
+            //        PARdrD = PARdir * (1.0-ref_dir) * np.exp(-kdr * iLAI)             # Total downward PAR due to direct radiation at canopy top
+            //        PARdfU = PARdif * (1.0-ref)     * np.exp(-kdf * LAI[j,i]) * \
+            //            albedo[j,i] * (1.0-ref)     * np.exp(-kdf * (LAI[j,i]-iLAI))  # Total upward (reflected) PAR that originates as diffuse radiation
+            //        PARdrU = PARdir * (1.0-ref_dir) * np.exp(-kdr * LAI[j,i]) * \
+            //            albedo[j,i] * (1.0-ref)     * np.exp(-kdf * (LAI[j,i]-iLAI))  # Total upward (reflected) PAR that originates as direct radiation
+            //        PARdfT = PARdfD + PARdfU                                          # Total PAR due to diffuse radiation at canopy top
+            //        PARdrT = PARdrD + PARdrU                                          # Total PAR due to direct radiation at canopy top
+
+            //        dirPAR = (1.0-sigma) * PARdir * fSL   # Purely direct PAR (can only be downward)
+            //        difPAR = PARdfT + PARdrT - dirPAR     # Total diffuse radiation
+
+            //        HdfT = kdf * PARdfD + kdf * PARdfU
+            //        HdrT = kdr * PARdrD + kdf * PARdrU
+            //        dirH = kdrbl * dirPAR
+            //        Hshad = HdfT + HdrT - dirH
+
+            //        Hsun = Hshad + angle_g * (1.0-sigma) * kdrbl * PARdir / angle_weight_sum
+
+            //        Hleaf[0] = Hshad
+            //        Hleaf[1:] = Hsun
+
+            //        Agl = fstr * (Am + Rdark) * (1 - np.exp(-alphac*Hleaf/(Am + Rdark)))
+            //        gleaf = gmin[ij]/nuco2q +  Agl/(co2_abs-ci)
+            //        Fleaf = Agl - Rdark
+
+            //        Fshad  = Fleaf[0]
+            //        Fsun   = np.sum(weight_g * Fleaf[1:])
+            //        gshad  = gleaf[0]
+            //        gsun   = np.sum(weight_g * gleaf[1:])
+
+            //        Fnet[it] = Fsun * fSL + Fshad * (1 - fSL)
+            //        gnet[it] = gsun * fSL + gshad * (1 - fSL)
+
+            //    An     = LAI[j,i] * np.sum(weight_g * Fnet)
+            //    gc_inf = LAI[j,i] * np.sum(weight_g * gnet)
+            //}
+            //else
+            //{
+                // Calculate upscaling from leaf to canopy: net flow CO2 into the plant (An)
+                const TF agsa1  = TF(1) / (TF(1) - f0[ij]);
+                const TF dstar  = dmax / (agsa1 * (f0[ij] - fmin));
+                const TF tempy  = alphac * kx * par / (am + rdark);
+
+                an     = (am + rdark) * (TF(1) - TF(1) / (kx * lai[ij]) * (e1_approx_g(tempy * exp(-kx * lai[ij])) - e1_approx_g(tempy)));
+                gc_inf = lai[ij] * (gmin[ij] / nuco2q + agsa1 * fstr * an / ((co2_abs - co2_comp) * (TF(1) + ds / dstar)));
+            //}
+
+            //if (lrelaxgc) then
+            //  if (gc_old_set) then
+            //    gcco2       = gc_old(i,j) + min(kgc*rk3coef, 1.0) * (gc_inf - gc_old(i,j))
+            //    if (rk3step ==3) then
+            //      gc_old(i,j) = gcco2
+            //    endif
+            //  else
+            //    gcco2 = gc_inf
+            //    gc_old(i,j) = gcco2
+            //  endif
+            //else
+            //    gcco2 = gc_inf
+            const TF gcco2 = gc_inf;
+
+            // Output values from kernel:
+            // Canopy resistances for moisture.
+            rs[ij] = TF(1) / (TF(1.6) * gcco2);
+
+            // Net flux of CO2 into the plant (An).
+            // `co2_abs` has units [mg(CO2) m-3(air)], so flux has units [mg(CO2) m-2 s-1)].
+            // Conversion with `to_mol` results in flux in [kmol(CO2) kmol-1(air) m s-1].
+            an_co2[ij] = (ci - co2_abs) / (ra[ij] + (TF(1) / gcco2)) * to_mol;
+        }
+    }
+
+
     template<typename TF> __global__
     void calc_soil_resistance_g(
             TF* const __restrict__ rs,
@@ -291,8 +534,8 @@ namespace Land_surface_kernels_g
             const TF* const __restrict__ lw_up,
             const TF* const __restrict__ b,
             const TF* const __restrict__ b_bot,
-            const TF* const __restrict__ rhorefh,
-            const TF* const __restrict__ exnerh,
+            const TF rho_bot,
+            const TF exner_bot,
             const TF db_ref,
             const TF emis_sfc,
             const TF dt,
@@ -304,9 +547,6 @@ namespace Land_surface_kernels_g
     {
         const int i = blockIdx.x*blockDim.x + threadIdx.x + istart;
         const int j = blockIdx.y*blockDim.y + threadIdx.y + jstart;
-
-        const TF exner_bot = exnerh[kstart];
-        const TF rho_bot = rhorefh[kstart];
 
         if (i < iend && j < jend)
         {
@@ -588,9 +828,9 @@ template<typename TF> __global__
             const TF* const __restrict__ thl_bot,
             const TF* const __restrict__ qt_bot,
             const TF* const __restrict__ ra,
-            const TF* const __restrict__ rhoh,
-            const TF* const __restrict__ prefh,
-            const TF* const __restrict__ exnerh,
+            const TF rho_bot,
+            const TF pref_bot,
+            const TF exner_bot,
             const int istart, const int iend,
             const int jstart, const int jend,
             const int kstart,
@@ -599,8 +839,8 @@ template<typename TF> __global__
         const int i = blockIdx.x*blockDim.x + threadIdx.x + istart;
         const int j = blockIdx.y*blockDim.y + threadIdx.y + jstart;
 
-        const TF rhocp = rhoh[kstart] * Constants::cp<TF>;
-        const TF rholv = rhoh[kstart] * Constants::Lv<TF>;
+        const TF rhocp = rho_bot * Constants::cp<TF>;
+        const TF rholv = rho_bot * Constants::Lv<TF>;
 
         if (i < iend && j < jend)
         {
@@ -609,8 +849,8 @@ template<typename TF> __global__
 
             if (water_mask[ij])
             {
-                thl_bot_wet[ij] = t_bot_water[ij] / exnerh[kstart];
-                qt_bot_wet[ij]  = Thermo_moist_functions::qsat(prefh[kstart], t_bot_water[ij]);
+                thl_bot_wet[ij] = t_bot_water[ij] / exner_bot;
+                qt_bot_wet[ij]  = Thermo_moist_functions::qsat(pref_bot, t_bot_water[ij]);
 
                 c_veg[ij]  = TF(0);
                 c_soil[ij] = TF(0);

--- a/include/land_surface_kernels_gpu.h
+++ b/include/land_surface_kernels_gpu.h
@@ -295,7 +295,7 @@ namespace Land_surface_kernels_g
             // Calculate CO2 concentration inside the leaf (ci).
             // NOTE: Differs from IFS
             const TF fmin0 = gmin[ij] / nuco2q - TF(1./9.) * gm;
-            const TF fmin = pow(-fmin0 + (fm::pow2(fmin0) + TF(4) * gmin[ij] / nuco2q * gm), TF(0.5)) / (TF(2) * gm);
+            const TF fmin = pow(max(-fmin0 + (fm::pow2(fmin0) + TF(4) * gmin[ij] / nuco2q * gm), TF(Constants::dsmall)), TF(0.5)) / (TF(2) * gm);
 
             // Calculate atmospheric moisture deficit.
             // "Therefore Ci/Cs is specified as a function of atmospheric moisture deficit Ds at the leaf surface".
@@ -443,6 +443,8 @@ namespace Land_surface_kernels_g
             // Conversion with `to_mol` results in flux in [kmol(CO2) kmol-1(air) m s-1].
             an_co2[ij] = (ci - co2_abs) / (ra[ij] + (TF(1) / gcco2)) * to_mol;
 
+
+            // Check!
             if (isnan(rs[ij]))
             {
                 printf("Canopy resistance contains NaNs!\n");

--- a/include/land_surface_kernels_gpu.h
+++ b/include/land_surface_kernels_gpu.h
@@ -1022,13 +1022,6 @@ template<typename TF> __global__
         cuda_safe_call(cudaMalloc(&tile.thl_bot_g, memsize_tf));
         cuda_safe_call(cudaMalloc(&tile.qt_bot_g, memsize_tf));
 
-        cuda_safe_call(cudaMalloc(&tile.obuk_g, memsize_tf));
-        cuda_safe_call(cudaMalloc(&tile.ustar_g, memsize_tf));
-        cuda_safe_call(cudaMalloc(&tile.bfluxbot_g, memsize_tf));
-        cuda_safe_call(cudaMalloc(&tile.ra_g, memsize_tf));
-
-        cuda_safe_call(cudaMalloc(&tile.nobuk_g, memsize_int));
-
         cuda_safe_call(cudaMalloc(&tile.rs_g, memsize_tf));
         cuda_safe_call(cudaMalloc(&tile.H_g, memsize_tf));
         cuda_safe_call(cudaMalloc(&tile.LE_g, memsize_tf));
@@ -1042,13 +1035,6 @@ template<typename TF> __global__
         cuda_safe_call(cudaFree(tile.fraction_g));
         cuda_safe_call(cudaFree(tile.thl_bot_g));
         cuda_safe_call(cudaFree(tile.qt_bot_g));
-
-        cuda_safe_call(cudaFree(tile.obuk_g));
-        cuda_safe_call(cudaFree(tile.ustar_g));
-        cuda_safe_call(cudaFree(tile.bfluxbot_g));
-        cuda_safe_call(cudaFree(tile.ra_g));
-
-        cuda_safe_call(cudaFree(tile.nobuk_g));
 
         cuda_safe_call(cudaFree(tile.rs_g));
         cuda_safe_call(cudaFree(tile.H_g));
@@ -1067,13 +1053,6 @@ template<typename TF> __global__
         cuda_safe_call(cudaMemcpy(tile.thl_bot_g, tile.thl_bot.data(), memsize_tf, cudaMemcpyHostToDevice));
         cuda_safe_call(cudaMemcpy(tile.qt_bot_g, tile.qt_bot.data(), memsize_tf, cudaMemcpyHostToDevice));
 
-        cuda_safe_call(cudaMemcpy(tile.obuk_g, tile.obuk.data(), memsize_tf, cudaMemcpyHostToDevice));
-        cuda_safe_call(cudaMemcpy(tile.ustar_g, tile.ustar.data(), memsize_tf, cudaMemcpyHostToDevice));
-        cuda_safe_call(cudaMemcpy(tile.bfluxbot_g, tile.bfluxbot.data(), memsize_tf, cudaMemcpyHostToDevice));
-        cuda_safe_call(cudaMemcpy(tile.ra_g, tile.ra.data(), memsize_tf, cudaMemcpyHostToDevice));
-
-        cuda_safe_call(cudaMemcpy(tile.nobuk_g, tile.nobuk.data(), memsize_int, cudaMemcpyHostToDevice));
-
         cuda_safe_call(cudaMemcpy(tile.rs_g, tile.rs.data(), memsize_tf, cudaMemcpyHostToDevice));
         cuda_safe_call(cudaMemcpy(tile.H_g, tile.H.data(), memsize_tf, cudaMemcpyHostToDevice));
         cuda_safe_call(cudaMemcpy(tile.LE_g, tile.LE.data(), memsize_tf, cudaMemcpyHostToDevice));
@@ -1090,13 +1069,6 @@ template<typename TF> __global__
         cuda_safe_call(cudaMemcpy(tile.fraction.data(), tile.fraction_g, memsize_tf, cudaMemcpyDeviceToHost));
         cuda_safe_call(cudaMemcpy(tile.thl_bot.data(), tile.thl_bot_g, memsize_tf, cudaMemcpyDeviceToHost));
         cuda_safe_call(cudaMemcpy(tile.qt_bot.data(), tile.qt_bot_g, memsize_tf, cudaMemcpyDeviceToHost));
-
-        cuda_safe_call(cudaMemcpy(tile.obuk.data(), tile.obuk_g, memsize_tf, cudaMemcpyDeviceToHost));
-        cuda_safe_call(cudaMemcpy(tile.ustar.data(), tile.ustar_g, memsize_tf, cudaMemcpyDeviceToHost));
-        cuda_safe_call(cudaMemcpy(tile.bfluxbot.data(), tile.bfluxbot_g, memsize_tf, cudaMemcpyDeviceToHost));
-        cuda_safe_call(cudaMemcpy(tile.ra.data(), tile.ra_g, memsize_tf, cudaMemcpyDeviceToHost));
-
-        cuda_safe_call(cudaMemcpy(tile.nobuk.data(), tile.nobuk_g, memsize_int, cudaMemcpyDeviceToHost));
 
         cuda_safe_call(cudaMemcpy(tile.rs.data(), tile.rs_g, memsize_tf, cudaMemcpyDeviceToHost));
         cuda_safe_call(cudaMemcpy(tile.H.data(), tile.H_g, memsize_tf, cudaMemcpyDeviceToHost));

--- a/include/radiation_rrtmgp.h
+++ b/include/radiation_rrtmgp.h
@@ -213,6 +213,7 @@ class Radiation_rrtmgp : public Radiation<TF>
         bool sw_delta_aer;
 
         bool swtimedep_background;
+        bool swtimedep_basestate;
         bool swtimedep_aerosol;
 
         bool sw_homogenize_sfc_sw;

--- a/include/soil_kernels.h
+++ b/include/soil_kernels.h
@@ -175,9 +175,11 @@ namespace Soil_kernels
     }
 
     template<typename TF>
-    void calc_root_weighted_mean_theta(
+    void calc_root_weighted_mean_values(
             TF* const restrict theta_mean,
+            TF* const restrict t_mean,
             const TF* const restrict theta,
+            const TF* const restrict t,
             const int* const restrict soil_index,
             const TF* const restrict root_fraction,
             const TF* const restrict theta_wp,
@@ -193,6 +195,7 @@ namespace Soil_kernels
             {
                 const int ij = i + j*icells;
                 theta_mean[ij] = TF(0);
+                t_mean[ij] = TF(0);
             }
 
         for (int k=kstart; k<kend; ++k)
@@ -207,6 +210,7 @@ namespace Soil_kernels
                     const TF theta_lim = std::max(theta[ijk], theta_wp[si]);
                     theta_mean[ij] += root_fraction[ijk]
                             * (theta_lim - theta_wp[si]) / (theta_fc[si] - theta_wp[si]);
+                    t_mean[ij] += root_fraction[ijk] * t[ijk];
                 }
     }
 

--- a/include/soil_kernels_gpu.h
+++ b/include/soil_kernels_gpu.h
@@ -55,9 +55,11 @@ namespace Soil_kernels_g
     }
 
     template<typename TF> __global__
-    void calc_root_weighted_mean_theta_g(
+    void calc_root_weighted_mean_values_g(
             TF* const __restrict__ theta_mean,
+            TF* const __restrict__ t_mean,
             const TF* const __restrict__ theta,
+            const TF* const __restrict__ t,
             const int* const __restrict__ soil_index,
             const TF* const __restrict__ root_fraction,
             const TF* const __restrict__ theta_wp,
@@ -84,6 +86,8 @@ namespace Soil_kernels_g
                 const TF theta_lim = fmax(theta[ijk], theta_wp[si]);
                 theta_mean[ij] += root_fraction[ijk]
                         * (theta_lim - theta_wp[si]) / (theta_fc[si] - theta_wp[si]);
+
+                t_mean[ij] += root_fraction[ijk] * t[ijk];
             }
         }
     }

--- a/include/thermo.h
+++ b/include/thermo.h
@@ -57,7 +57,7 @@ class Thermo
         virtual void init() = 0;
         virtual void create(
                 Input&, Netcdf_handle&, Stats<TF>&, Column<TF>&, Cross<TF>&, Dump<TF>&, Timeloop<TF>&) = 0;
-        virtual void create_basestate(Input&, Netcdf_handle&) = 0;
+        virtual void create_basestate(Input&, Netcdf_handle&, Timeloop<TF>&) = 0;
         virtual unsigned long get_time_limit(unsigned long, double) = 0;
         virtual void load(const int) = 0;
         virtual void save(const int) = 0;

--- a/include/thermo.h
+++ b/include/thermo.h
@@ -87,7 +87,8 @@ class Thermo
                 Field3d<TF>&, Field3d<TF>&, Field3d<TF>&, Field3d<TF>&, Field3d<TF>&, Field3d<TF>&) const = 0;
         virtual void get_radiation_columns(Field3d<TF>&, std::vector<int>&, std::vector<int>&) const = 0;
         virtual void get_land_surface_fields(
-                std::vector<TF>&, std::vector<TF>&, std::vector<TF>&, std::vector<TF>&, std::vector<TF>&) = 0;
+                std::vector<TF>&, std::vector<TF>&, std::vector<TF>&,
+                std::vector<TF>&, std::vector<TF>&, std::vector<TF>&) = 0;
 
         virtual const std::vector<TF>& get_basestate_vector(std::string) const = 0;
         virtual TF get_db_ref() const = 0;

--- a/include/thermo.h
+++ b/include/thermo.h
@@ -108,7 +108,7 @@ class Thermo
         virtual void get_buoyancy_surf_g(Field3d<TF>&)  = 0;
         virtual void get_buoyancy_surf_g(TF*, TF*, TF*)  = 0;
         virtual void get_buoyancy_fluxbot_g(Field3d<TF>&) = 0;
-        virtual void get_land_surface_fields_g(TF*, TF*, TF*, TF*, TF*) = 0;
+        virtual void get_land_surface_fields_g(TF*, TF*, TF*, TF*, TF*, TF*) = 0;
         virtual TF* get_basestate_fld_g(std::string) = 0;
 
         virtual void get_radiation_fields_g(

--- a/include/thermo_buoy.h
+++ b/include/thermo_buoy.h
@@ -87,7 +87,7 @@ class Thermo_buoy : public Thermo<TF>
 
         // Empty functions that are allowed to pass.
         void init() {}
-        void create_basestate(Input&, Netcdf_handle&) {};
+        void create_basestate(Input&, Netcdf_handle&, Timeloop<TF>&) {};
         void load(const int) {};
         void save(const int) {};
         void exec_stats(Stats<TF>&) {};

--- a/include/thermo_buoy.h
+++ b/include/thermo_buoy.h
@@ -80,7 +80,7 @@ class Thermo_buoy : public Thermo<TF>
             { throw std::runtime_error("Function get_radiation_columns not implemented"); }
         void get_land_surface_fields(
                 std::vector<TF>&, std::vector<TF>&, std::vector<TF>&,
-                std::vector<TF>&, std::vector<TF>&)
+                std::vector<TF>&, std::vector<TF>&, std::vector<TF>&)
             { throw std::runtime_error("Function get_land_surface_fields not implemented"); }
         const std::vector<TF>& get_basestate_vector(std::string) const
             { throw std::runtime_error("Function get_basestate_vector not implemented"); }

--- a/include/thermo_buoy.h
+++ b/include/thermo_buoy.h
@@ -115,7 +115,7 @@ class Thermo_buoy : public Thermo<TF>
             { throw std::runtime_error("Function get_radiation_fields_g not implemented"); }
         void get_radiation_columns_g(Field3d<TF>&, const int*, const int*, const int) const
             { throw std::runtime_error("Function get_radiation_columns_g not implemented"); }
-        void get_land_surface_fields_g(TF*, TF*, TF*, TF*, TF*)
+        void get_land_surface_fields_g(TF*, TF*, TF*, TF*, TF*, TF*)
             { throw std::runtime_error("Function \"get_land_surface_fields_g\" not implemented in thermo_disabled"); };
         void get_buoyancy_surf_g(TF*, TF*, TF*)
             { throw std::runtime_error("Function \"get_buoyancy_surf_g\" not implemented in thermo_disabled"); };

--- a/include/thermo_disabled.h
+++ b/include/thermo_disabled.h
@@ -54,7 +54,7 @@ class Thermo_disabled : public Thermo<TF>
         // Interfacing functions to get buoyancy properties from other classes.
         void init() {};
         void create(Input&, Netcdf_handle&, Stats<TF>&, Column<TF>&, Cross<TF>&, Dump<TF>&, Timeloop<TF>&) {};
-        void create_basestate(Input&, Netcdf_handle&) {};
+        void create_basestate(Input&, Netcdf_handle&, Timeloop<TF>&) {};
         void load(const int) {};
         void save(const int) {};
         void exec(const double, Stats<TF>&) {};

--- a/include/thermo_disabled.h
+++ b/include/thermo_disabled.h
@@ -109,7 +109,7 @@ class Thermo_disabled : public Thermo<TF>
             { throw std::runtime_error("Function get_radiation_columns not implemented"); }
         void get_land_surface_fields(
                 std::vector<TF>&, std::vector<TF>&, std::vector<TF>&,
-                std::vector<TF>&, std::vector<TF>&)
+                std::vector<TF>&, std::vector<TF>&, std::vector<TF>&)
             { throw std::runtime_error("Function get_land_surface_fields not implemented"); }
         void get_buoyancy_surf(std::vector<TF>&, std::vector<TF>&, bool)
             { throw std::runtime_error("Function get_buoyancy_surf not implemented"); }

--- a/include/thermo_disabled.h
+++ b/include/thermo_disabled.h
@@ -84,7 +84,7 @@ class Thermo_disabled : public Thermo<TF>
             { throw std::runtime_error("Function \"get_buoyancy_fluxbot_g\" not implemented in thermo_disabled"); }
         TF* get_basestate_fld_g(std::string)
             { throw std::runtime_error("Function \"get_basestate_fld_g\" not implemented in thermo_disabled"); }
-        void get_land_surface_fields_g(TF*, TF*, TF*, TF*, TF*)
+        void get_land_surface_fields_g(TF*, TF*, TF*, TF*, TF*, TF*)
             { throw std::runtime_error("Function \"get_land_surface_fields_g\" not implemented in thermo_disabled"); };
         void get_radiation_fields_g(Field3d<TF>&, Field3d<TF>&, Field3d<TF>&, Field3d<TF>&, Field3d<TF>&) const
             { throw std::runtime_error("Function get_radiation_fields_g not implemented"); }

--- a/include/thermo_dry.h
+++ b/include/thermo_dry.h
@@ -121,7 +121,7 @@ class Thermo_dry : public Thermo<TF>
             { throw std::runtime_error("Function get_land_surface_fields not implemented"); }
 
         // Empty functions that are allowed to pass.
-        void create_basestate(Input&, Netcdf_handle&) {};
+        void create_basestate(Input&, Netcdf_handle&, Timeloop<TF>&) {};
         void load(const int) {};
         void save(const int) {};
 

--- a/include/thermo_dry.h
+++ b/include/thermo_dry.h
@@ -117,7 +117,7 @@ class Thermo_dry : public Thermo<TF>
             { throw std::runtime_error("Function get_radiation_columns not implemented"); }
         void get_land_surface_fields(
                 std::vector<TF>&, std::vector<TF>&, std::vector<TF>&,
-                std::vector<TF>&, std::vector<TF>&)
+                std::vector<TF>&, std::vector<TF>&, std::vector<TF>&)
             { throw std::runtime_error("Function get_land_surface_fields not implemented"); }
 
         // Empty functions that are allowed to pass.

--- a/include/thermo_dry.h
+++ b/include/thermo_dry.h
@@ -102,7 +102,7 @@ class Thermo_dry : public Thermo<TF>
             { throw std::runtime_error("Function get_radiation_fields_g not implemented"); }
         void get_radiation_columns_g(Field3d<TF>&, const int*, const int*, const int) const
             { throw std::runtime_error("Function get_radiation_columns_g not implemented"); }
-        void get_land_surface_fields_g(TF*, TF*, TF*, TF*, TF*)
+        void get_land_surface_fields_g(TF*, TF*, TF*, TF*, TF*, TF*)
             { throw std::runtime_error("Function \"get_land_surface_fields_g\" not implemented in thermo_dry"); };
         void get_buoyancy_surf_g(TF*, TF*, TF*)
             { throw std::runtime_error("Function \"get_buoyancy_surf_g\" not implemented in thermo_disabled"); };

--- a/include/thermo_moist.h
+++ b/include/thermo_moist.h
@@ -59,7 +59,7 @@ class Thermo_moist : public Thermo<TF>
 
         void init();
         void create(Input&, Netcdf_handle&, Stats<TF>&, Column<TF>&, Cross<TF>&, Dump<TF>&, Timeloop<TF>&);
-        void create_basestate(Input&, Netcdf_handle&);
+        void create_basestate(Input&, Netcdf_handle&, Timeloop<TF>&);
 
         void exec(const double, Stats<TF>&); ///< Add the tendencies belonging to the buoyancy.
         unsigned long get_time_limit(unsigned long, double); ///< Compute the time limit (n/a for thermo_dry)

--- a/include/thermo_moist.h
+++ b/include/thermo_moist.h
@@ -114,7 +114,7 @@ class Thermo_moist : public Thermo<TF>
         void get_radiation_fields_g(
                 Field3d<TF>&, Field3d<TF>&, Field3d<TF>&, Field3d<TF>&, Field3d<TF>&, Field3d<TF>&) const;
         void get_radiation_columns_g(Field3d<TF>&, const int*, const int*, const int) const;
-        void get_land_surface_fields_g(TF*, TF*, TF*, TF*, TF*);
+        void get_land_surface_fields_g(TF*, TF*, TF*, TF*, TF*, TF*);
         #endif
 
         // Empty functions that are allowed to pass.

--- a/include/thermo_moist.h
+++ b/include/thermo_moist.h
@@ -80,7 +80,8 @@ class Thermo_moist : public Thermo<TF>
                 Field3d<TF>&, Field3d<TF>&, Field3d<TF>&, Field3d<TF>&, Field3d<TF>&, Field3d<TF>&) const;
         void get_radiation_columns(Field3d<TF>&, std::vector<int>&, std::vector<int>&) const;
         void get_land_surface_fields(
-            std::vector<TF>&, std::vector<TF>&, std::vector<TF>&, std::vector<TF>&, std::vector<TF>&);
+                std::vector<TF>&, std::vector<TF>&, std::vector<TF>&,
+                std::vector<TF>&, std::vector<TF>&, std::vector<TF>&);
         void get_buoyancy_surf(std::vector<TF>&, std::vector<TF>&, bool);
         void get_buoyancy_surf(std::vector<TF>&, std::vector<TF>&, std::vector<TF>&);
         void get_buoyancy_fluxbot(std::vector<TF>&, bool);

--- a/src/boundary_surface_lsm.cu
+++ b/src/boundary_surface_lsm.cu
@@ -1190,8 +1190,11 @@ void Boundary_surface_lsm<TF>::backward_device(Thermo<TF>& thermo)
     for (auto& tile : tiles)
         lsmk::backward_device_tile(tile.second, gd.ijcells);
 
-    cuda_safe_call(cudaMemcpy(an_co2.data(), an_co2_g, tf_memsize_ij, cudaMemcpyDeviceToHost));
-    cuda_safe_call(cudaMemcpy(resp_co2.data(), resp_co2_g, tf_memsize_ij, cudaMemcpyDeviceToHost));
+    if (sw_ags)
+    {
+        cuda_safe_call(cudaMemcpy(an_co2.data(), an_co2_g, tf_memsize_ij, cudaMemcpyDeviceToHost));
+        cuda_safe_call(cudaMemcpy(resp_co2.data(), resp_co2_g, tf_memsize_ij, cudaMemcpyDeviceToHost));
+    }
 }
 
 template<typename TF>

--- a/src/boundary_surface_lsm.cu
+++ b/src/boundary_surface_lsm.cu
@@ -823,6 +823,12 @@ void Boundary_surface_lsm<TF>::exec_column(Column<TF>& column)
     get_tiled_mean_g(tmp->fld_bot_g, "S", TF(1));
     column.calc_time_series("S", tmp->fld_bot_g, no_offset);
 
+    if (sw_ags)
+    {
+        column.calc_time_series("co2_an", an_co2_g, no_offset);
+        column.calc_time_series("co2_resp", resp_co2_g, no_offset);
+    }
+
     if (sw_tile_stats_col)
         for (auto& tile : tiles)
         {

--- a/src/boundary_surface_lsm.cu
+++ b/src/boundary_surface_lsm.cu
@@ -1189,6 +1189,9 @@ void Boundary_surface_lsm<TF>::backward_device(Thermo<TF>& thermo)
     // Nearly all tile fields are used in the statistics:
     for (auto& tile : tiles)
         lsmk::backward_device_tile(tile.second, gd.ijcells);
+
+    cuda_safe_call(cudaMemcpy(an_co2.data(), an_co2_g, tf_memsize_ij, cudaMemcpyDeviceToHost));
+    cuda_safe_call(cudaMemcpy(resp_co2.data(), resp_co2_g, tf_memsize_ij, cudaMemcpyDeviceToHost));
 }
 
 template<typename TF>

--- a/src/boundary_surface_lsm.cu
+++ b/src/boundary_surface_lsm.cu
@@ -259,23 +259,19 @@ void Boundary_surface_lsm<TF>::exec(
     {
         // Calculate vegetation/soil resistance functions `f`.
         lsmk::calc_resistance_functions_g<<<grid_gpu_2d, block_gpu_2d>>>(
-                f1, f2, f2b, f3,
+                f1,
+                f2,
+                f3,
                 sw_dn,
-                fields.sps.at("theta")->fld_g,
-                theta_mean_n, vpd,
+                theta_mean_n,
+                vpd,
                 gD_coeff_g,
-                c_veg_g,
-                theta_wp_g,
-                theta_fc_g,
-                theta_res_g,
-                soil_index_g,
                 gd.istart, gd.iend,
                 gd.jstart, gd.jend,
-                sgd.kend,
                 gd.icells, gd.ijcells);
         cuda_check_error();
 
-        // Calculate canopy resistance for veg and soil tiles.
+        // Calculate canopy resistance for vegetation.
         lsmk::calc_canopy_resistance_g<<<grid_gpu_2d, block_gpu_2d>>>(
                 tiles.at("veg").rs_g,
                 rs_veg_min_g, lai_g,
@@ -285,6 +281,21 @@ void Boundary_surface_lsm<TF>::exec(
                 gd.icells);
         cuda_check_error();
     }
+
+    // Calculate soil resistance functions `f2b`.
+    lsmk::calc_soil_resistance_function_g<<<grid_gpu_2d, block_gpu_2d>>>(
+            f2b,
+            fields.sps.at("theta")->fld_g,
+            c_veg_g,
+            theta_wp_g,
+            theta_fc_g,
+            theta_res_g,
+            soil_index_g,
+            gd.istart, gd.iend,
+            gd.jstart, gd.jend,
+            sgd.kend,
+            gd.icells, gd.ijcells);
+    cuda_check_error();
 
     lsmk::calc_soil_resistance_g<<<grid_gpu_2d, block_gpu_2d>>>(
             tiles.at("soil").rs_g,

--- a/src/boundary_surface_lsm.cu
+++ b/src/boundary_surface_lsm.cu
@@ -243,6 +243,14 @@ void Boundary_surface_lsm<TF>::exec(
                 gd.istart, gd.iend,
                 gd.jstart, gd.jend,
                 gd.icells);
+
+        lsmk::set_net_co2_flux_g<TF><<<grid_gpu_2d, block_gpu_2d>>>(
+                fields.sp.at("co2")->flux_bot_g,
+                an_co2_g,
+                resp_co2_g,
+                gd.istart, gd.iend,
+                gd.jstart, gd.jend,
+                gd.icells);
     }
     else
     {

--- a/src/boundary_surface_lsm.cu
+++ b/src/boundary_surface_lsm.cu
@@ -952,6 +952,28 @@ void Boundary_surface_lsm<TF>::prepare_device(Thermo<TF>& thermo)
     cuda_safe_call(cudaMalloc(&source_g, tf_memsize_ijk));
     cuda_safe_call(cudaMalloc(&root_fraction_g, tf_memsize_ijk));
 
+    if (sw_ags)
+    {
+        // 3.1 A-Gs and soil respiration parameters.
+        cuda_safe_call(cudaMalloc(&alpha0_g, tf_memsize_ij));
+        cuda_safe_call(cudaMalloc(&t1gm_g, tf_memsize_ij));
+        cuda_safe_call(cudaMalloc(&t2gm_g, tf_memsize_ij));
+        cuda_safe_call(cudaMalloc(&t1am_g, tf_memsize_ij));
+        cuda_safe_call(cudaMalloc(&gm298_g, tf_memsize_ij));
+        cuda_safe_call(cudaMalloc(&gmin_g, tf_memsize_ij));
+        cuda_safe_call(cudaMalloc(&ammax298_g, tf_memsize_ij));
+        cuda_safe_call(cudaMalloc(&f0_g, tf_memsize_ij));
+        cuda_safe_call(cudaMalloc(&co2_comp298_g, tf_memsize_ij));
+
+        // Soil respiration.
+        cuda_safe_call(cudaMalloc(&r10_g, tf_memsize_ij));
+        cuda_safe_call(cudaMalloc(&ea_g, tf_memsize_ij));
+
+        // Surface CO2 fluxes.
+        cuda_safe_call(cudaMalloc(&an_co2_g, tf_memsize_ij));
+        cuda_safe_call(cudaMalloc(&resp_co2_g, tf_memsize_ij));
+    }
+
     // 4. Init lookup table with van Genuchten parameters:
     const int memsize_vg_lut = theta_res.size() * sizeof(TF);
 
@@ -1043,6 +1065,24 @@ void Boundary_surface_lsm<TF>::forward_device(Thermo<TF>& thermo)
     cuda_safe_call(cudaMemcpy(conductivity_h_g, conductivity_h.data(), tf_memsize_ijk, cudaMemcpyHostToDevice));
     cuda_safe_call(cudaMemcpy(source_g, source.data(), tf_memsize_ijk, cudaMemcpyHostToDevice));
     cuda_safe_call(cudaMemcpy(root_fraction_g, root_fraction.data(), tf_memsize_ijk, cudaMemcpyHostToDevice));
+
+    if (sw_ags)
+    {
+        // 3.1 Copy A-Gs parameters.
+        cuda_safe_call(cudaMemcpy(alpha0_g, alpha0.data(), int_memsize_ij, cudaMemcpyHostToDevice));
+        cuda_safe_call(cudaMemcpy(t1gm_g, t1gm.data(), int_memsize_ij, cudaMemcpyHostToDevice));
+        cuda_safe_call(cudaMemcpy(t2gm_g, t2gm.data(), int_memsize_ij, cudaMemcpyHostToDevice));
+        cuda_safe_call(cudaMemcpy(t1am_g, t1am.data(), int_memsize_ij, cudaMemcpyHostToDevice));
+        cuda_safe_call(cudaMemcpy(gm298_g, gm298.data(), int_memsize_ij, cudaMemcpyHostToDevice));
+        cuda_safe_call(cudaMemcpy(gmin_g, gmin.data(), int_memsize_ij, cudaMemcpyHostToDevice));
+        cuda_safe_call(cudaMemcpy(ammax298_g, ammax298.data(), int_memsize_ij, cudaMemcpyHostToDevice));
+        cuda_safe_call(cudaMemcpy(f0_g, f0.data(), int_memsize_ij, cudaMemcpyHostToDevice));
+        cuda_safe_call(cudaMemcpy(co2_comp298_g, co2_comp298.data(), int_memsize_ij, cudaMemcpyHostToDevice));
+
+        // Soil respiration.
+        cuda_safe_call(cudaMemcpy(r10_g, r10.data(), int_memsize_ij, cudaMemcpyHostToDevice));
+        cuda_safe_call(cudaMemcpy(ea_g, ea.data(), int_memsize_ij, cudaMemcpyHostToDevice));
+    }
 
     // 4. Copy lookup table with van Genuchten parameters:
     const int memsize_vg_lut = theta_res.size() * sizeof(TF);
@@ -1137,6 +1177,25 @@ void Boundary_surface_lsm<TF>::clear_device(Thermo<TF>& thermo)
     cuda_safe_call(cudaFree(conductivity_h_g));
     cuda_safe_call(cudaFree(source_g));
     cuda_safe_call(cudaFree(root_fraction_g));
+
+    if (sw_ags)
+    {
+        cuda_safe_call(cudaFree(alpha0_g));
+        cuda_safe_call(cudaFree(t1gm_g));
+        cuda_safe_call(cudaFree(t2gm_g));
+        cuda_safe_call(cudaFree(t1am_g));
+        cuda_safe_call(cudaFree(gm298_g));
+        cuda_safe_call(cudaFree(gmin_g));
+        cuda_safe_call(cudaFree(ammax298_g));
+        cuda_safe_call(cudaFree(f0_g));
+        cuda_safe_call(cudaFree(co2_comp298_g));
+
+        cuda_safe_call(cudaFree(r10_g));
+        cuda_safe_call(cudaFree(ea_g));
+
+        cuda_safe_call(cudaFree(an_co2_g));
+        cuda_safe_call(cudaFree(resp_co2_g));
+    }
 
     cuda_safe_call(cudaFree(theta_res_g));
     cuda_safe_call(cudaFree(theta_wp_g));

--- a/src/boundary_surface_lsm.cu
+++ b/src/boundary_surface_lsm.cu
@@ -233,6 +233,7 @@ void Boundary_surface_lsm<TF>::exec(
                 gd.kstart,
                 gd.icells,
                 gd.ijcells);
+        cuda_check_error();
 
         lsmk::calc_soil_respiration_jacobs_g<TF><<<grid_gpu_2d, block_gpu_2d>>>(
                 resp_co2_g,
@@ -243,6 +244,7 @@ void Boundary_surface_lsm<TF>::exec(
                 gd.istart, gd.iend,
                 gd.jstart, gd.jend,
                 gd.icells);
+        cuda_check_error();
 
         lsmk::set_net_co2_flux_g<TF><<<grid_gpu_2d, block_gpu_2d>>>(
                 fields.sp.at("co2")->flux_bot_g,
@@ -251,6 +253,7 @@ void Boundary_surface_lsm<TF>::exec(
                 gd.istart, gd.iend,
                 gd.jstart, gd.jend,
                 gd.icells);
+        cuda_check_error();
     }
     else
     {

--- a/src/boundary_surface_lsm.cxx
+++ b/src/boundary_surface_lsm.cxx
@@ -365,11 +365,12 @@ void Boundary_surface_lsm<TF>::exec(
     auto T_bot = fields.get_tmp_xy();
     auto T_a = fields.get_tmp_xy();
     auto vpd = fields.get_tmp_xy();
+    auto vpds = fields.get_tmp_xy();
     auto qsat_bot = fields.get_tmp_xy();
     auto dqsatdT_bot = fields.get_tmp_xy();
 
     thermo.get_land_surface_fields(
-        *T_bot, *T_a, *vpd, *qsat_bot, *dqsatdT_bot);
+        *T_bot, *T_a, *vpd, *vpds, *qsat_bot, *dqsatdT_bot);
 
     // NOTE: `get_buoyancy_surf` calculates the first model level buoyancy only,
     //       but since this is written at `kstart`, we can't use a 2D slice...

--- a/src/boundary_surface_lsm.cxx
+++ b/src/boundary_surface_lsm.cxx
@@ -1514,9 +1514,6 @@ void Boundary_surface_lsm<TF>::load(const int iotime, Thermo<TF>& thermo)
     // Obukhov length restart files are only needed for the iterative solver
     if (!sw_constant_z0)
     {
-        // Read Obukhov length
-        load_2d_field(obuk.data(), "obuk", iotime);
-
         // Read spatial z0 fields
         load_2d_field(z0m.data(), "z0m", 0);
         load_2d_field(z0h.data(), "z0h", 0);
@@ -1533,6 +1530,9 @@ void Boundary_surface_lsm<TF>::load(const int iotime, Thermo<TF>& thermo)
     {
         load_2d_field(tile.second.thl_bot.data(), "thl_bot_" + tile.first, iotime);
         load_2d_field(tile.second.qt_bot.data(),  "qt_bot_"  + tile.first, iotime);
+
+        if (!sw_constant_z0)
+            load_2d_field(tile.second.obuk.data(), "obuk_" + tile.first, iotime);
     }
 
     // In case of heterogeneous land-surface, read spatial properties.
@@ -1633,10 +1633,6 @@ void Boundary_surface_lsm<TF>::save(const int iotime, Thermo<TF>& thermo)
     save_2d_field(dvdz_mo.data(), "dvdz_mo");
     save_2d_field(dbdz_mo.data(), "dbdz_mo");
 
-    // Obukhov length restart files are only needed for the iterative solver.
-    if (!sw_constant_z0)
-        save_2d_field(obuk.data(), "obuk");
-
     // Don't save the initial soil temperature/moisture for heterogeneous runs.
     if (sw_homogeneous || iotime > 0)
     {
@@ -1651,6 +1647,9 @@ void Boundary_surface_lsm<TF>::save(const int iotime, Thermo<TF>& thermo)
     {
         save_2d_field(tile.second.thl_bot.data(), "thl_bot_" + tile.first);
         save_2d_field(tile.second.qt_bot.data(),  "qt_bot_"  + tile.first);
+
+        if (!sw_constant_z0)
+            save_2d_field(tile.second.obuk.data(),  "obuk_"  + tile.first);
     }
 
     // Check for any failures.

--- a/src/boundary_surface_lsm.cxx
+++ b/src/boundary_surface_lsm.cxx
@@ -397,6 +397,7 @@ void Boundary_surface_lsm<TF>::exec(
     auto f2b = fields.get_tmp_xy();
     auto f3  = fields.get_tmp_xy();
     auto theta_mean_n = fields.get_tmp_xy();
+    auto t_mean_n = fields.get_tmp_xy();
 
     const double subdt = timeloop.get_sub_time_step();
 
@@ -419,10 +420,12 @@ void Boundary_surface_lsm<TF>::exec(
             gd.jstart, gd.jend,
             gd.icells);
 
-    // Calculate root fraction weighted mean soil water content
-    sk::calc_root_weighted_mean_theta(
+    // Calculate root fraction weighted mean soil temperature and water content
+    sk::calc_root_weighted_mean_values(
             (*theta_mean_n).data(),
+            (*t_mean_n).data(),
             fields.sps.at("theta")->fld.data(),
+            fields.sps.at("t")->fld.data(),
             soil_index.data(),
             root_fraction.data(),
             theta_wp.data(),
@@ -468,6 +471,16 @@ void Boundary_surface_lsm<TF>::exec(
                 gd.kstart,
                 gd.icells,
                 gd.ijcells);
+
+        lsmk::calc_soil_respiration_jacobs(
+                resp_co2.data(),
+                (*t_mean_n).data(),
+                r10.data(),
+                ea.data(),
+                rhorefh[gd.kstart],
+                gd.istart, gd.iend,
+                gd.jstart, gd.jend,
+                gd.icells);
     }
     else
     {
@@ -981,6 +994,7 @@ void Boundary_surface_lsm<TF>::exec(
     fields.release_tmp_xy(f2b);
     fields.release_tmp_xy(f3);
     fields.release_tmp_xy(theta_mean_n);
+    fields.release_tmp_xy(t_mean_n);
 }
 #endif
 

--- a/src/boundary_surface_lsm.cxx
+++ b/src/boundary_surface_lsm.cxx
@@ -464,7 +464,6 @@ void Boundary_surface_lsm<TF>::exec(
                 // cos_sza, only for splitleaf...
                 rhoref[gd.kstart],
                 rhorefh[gd.kstart],
-                prefh[gd.kstart],
                 sw_splitleaf,
                 gd.istart, gd.iend,
                 gd.jstart, gd.jend,

--- a/src/boundary_surface_lsm.cxx
+++ b/src/boundary_surface_lsm.cxx
@@ -384,6 +384,7 @@ void Boundary_surface_lsm<TF>::exec(
     thermo.get_buoyancy_surf(buoy->fld, *b_bot, false);
     const TF db_ref = thermo.get_db_ref();
 
+    const std::vector<TF>& rhoref = thermo.get_basestate_vector("rho");
     const std::vector<TF>& rhorefh = thermo.get_basestate_vector("rhoh");
     const std::vector<TF>& thvrefh = thermo.get_basestate_vector("thvh");
     const std::vector<TF>& exnrefh = thermo.get_basestate_vector("exnerh");
@@ -436,61 +437,39 @@ void Boundary_surface_lsm<TF>::exec(
 
     if (sw_ags)
     {
-        //lsmk::calc_canopy_resistance_ags(
-        //        tiles.at("veg").rs.data(),
-        //        an_co2.data(),
-        //        lai.data(),
-        //        (*T_bot).data(),
-        //        tiles.at("veg").ra.data(),
-        //        fields.sp.at("co2")->fld.data(),
-        //        fields.sp.at("thl")->fld.data(),
-        //        fields.sp.at("qt")->fld.data(),
-        //        sw_dn.data(),
-        //        (*theta_mean_n).data(),
-        //        // albedo, only for splitleaf...
-        //        (*vpds).data(),
-        //        ags_index.data(),
-        //        alpha0.data(),
-        //        t2gm.data(),
-        //        gm298.data(),
-        //        gmin.data(),
-        //        ammax298.data(),
-        //        f0.data(),
-        //        co2_comp298.data(),
+        bool sw_splitleaf = false;
 
-        //void calc_canopy_resistance_ags(
-        //    TF* const restrict rs,
-        //    TF* const restrict an_co2,
-        //    const TF* const restrict lai,
-        //    const TF* const restrict t_bot,
-        //    const TF* const restrict ra,
-        //    const TF* const restrict co2,
-        //    const TF* const restrict thl,
-        //    const TF* const restrict qt,
-        //    const TF* const restrict sw_flux_dn,
-        //    const TF* const restrict theta_rel_mean,
-        //    const TF* const restrict albedo,
-        //    const TF* const restrict vpds,
-        //    const int* const restrict ags_index,
-        //    // Vegetation specific constants:
-        //    const TF* const restrict alpha0,
-        //    const TF* const restrict t2gm,
-        //    const TF* const restrict gm298,
-        //    const TF* const restrict gmin,
-        //    const TF* const restrict ammax298,
-        //    const TF* const restrict f0,
-        //    const TF* const restrict co2_comp298,
-        //    const TF cos_sza,
-        //    const TF rho,
-        //    const TF rho_bot,
-        //    const TF p_bot,
-        //    const bool sw_splitleaf,
-        //    const int istart, const int iend,
-        //    const int jstart, const int jend,
-        //    const int kstart,
-        //    const int jstride,
-        //    const int kstride)
-
+        lsmk::calc_canopy_resistance_ags<TF>(
+                tiles.at("veg").rs.data(),
+                an_co2.data(),
+                lai.data(),
+                (*T_bot).data(),
+                tiles.at("veg").ra.data(),
+                fields.sp.at("co2")->fld.data(),
+                fields.sp.at("thl")->fld.data(),
+                fields.sp.at("qt")->fld.data(),
+                sw_dn.data(),
+                (*theta_mean_n).data(),
+                // albedo, only for splitleaf...
+                (*vpds).data(),
+                ags_index.data(),
+                alpha0.data(),
+                t2gm.data(),
+                gm298.data(),
+                gmin.data(),
+                ammax298.data(),
+                f0.data(),
+                co2_comp298.data(),
+                // cos_sza, only for splitleaf...
+                rhoref[gd.kstart],
+                rhorefh[gd.kstart],
+                prefh[gd.kstart],
+                sw_splitleaf,
+                gd.istart, gd.iend,
+                gd.jstart, gd.jend,
+                gd.kstart,
+                gd.icells,
+                gd.ijcells);
     }
     else
     {

--- a/src/column.cxx
+++ b/src/column.cxx
@@ -101,8 +101,18 @@ void Column<TF>::create(Input& inputin, Timeloop<TF>& timeloop, std::string sim_
         i = std::min(i, gd.itot-1);
         j = std::min(j, gd.jtot-1);
 
-        columns.emplace_back(Column_struct{});
-        columns.back().coord = {i, j};
+        bool is_duplicate = false;
+        for (auto& col : columns)
+            if (col.coord[0] == i && col.coord[1] == j)
+            {
+                is_duplicate = true;
+                master.print_warning("Column #" + std::to_string(n) + " is a duplicate!");
+            }
+        if (!is_duplicate)
+        {
+            columns.emplace_back(Column_struct{});
+            columns.back().coord = {i, j};
+        }
     }
 
     // Create a NetCDF file for the statistics.

--- a/src/model.cxx
+++ b/src/model.cxx
@@ -312,7 +312,7 @@ void Model<TF>::save()
             timeloop->get_idt(),
             timeloop->get_iteration());
 
-    thermo->create_basestate(*input, *input_nc);
+    thermo->create_basestate(*input, *input_nc, *timeloop);
     thermo->save(timeloop->get_iotime());
 
     boundary->create_cold_start(*input_nc);

--- a/src/radiation_gcss.cu
+++ b/src/radiation_gcss.cu
@@ -258,7 +258,7 @@ void Radiation_gcss<TF>::exec(Thermo<TF>& thermo, double time, Timeloop<TF>& tim
     if (mu > mu_min)
     {
         calc_gcss_rad_SW_g<TF><<<gridGPU2D, blockGPU>>>(flx->fld_g, ql->fld_g, fields.sp.at("qt")->fld_g,
-            tmp->fld_g, fields.rhoref_g, mu, gd.z_g, gd.dzi_g,
+            tmp->fld_g, fields.rhoref_g, mu, gd.z_g, gd.dz_g,
             gd.istart, gd.iend, gd.jstart, gd.jend, gd.kstart, gd.kend,
             gd.icells, gd.ijcells, gd.ncells);
 
@@ -337,7 +337,7 @@ void Radiation_gcss<TF>::get_radiation_field_g(Field3d<TF>& fld, std::string nam
             thermo.get_thermo_field_g(*ql,"ql",false);
             calc_gcss_rad_SW_g<TF><<<gridGPU, blockGPU>>>(
                 fld.fld_g, ql->fld_g, fields.sp.at("qt")->fld_g,
-                tau->fld_g, fields.rhoref_g, mu, gd.z_g, gd.dzi_g,
+                tau->fld_g, fields.rhoref_g, mu, gd.z_g, gd.dz_g,
                 gd.istart, gd.iend, gd.jstart, gd.jend, gd.kstart, gd.kend,
                 gd.icells, gd.ijcells, gd.ncells);
 

--- a/src/radiation_rrtmgp.cu
+++ b/src/radiation_rrtmgp.cu
@@ -1215,7 +1215,7 @@ void Radiation_rrtmgp<TF>::exec(
 
             if (sw_longwave)
             {
-                if (swtimedep_background)
+                if (swtimedep_background || swtimedep_basestate)
                 {
                     // Calculate new background column (on the CPU).
                     Float* ph_g = thermo.get_basestate_fld_g("prefh");

--- a/src/thermo_moist.cu
+++ b/src/thermo_moist.cu
@@ -444,6 +444,7 @@ namespace
         TF* const __restrict__ T_bot,
         TF* const __restrict__ T_a,
         TF* const __restrict__ vpd,
+        TF* const __restrict__ vpds,
         TF* const __restrict__ qsat_bot,
         TF* const __restrict__ dqsatdT_bot,
         const TF* const __restrict__ thl_bot,
@@ -476,6 +477,10 @@ namespace
             const TF es = esat(ssa.t);
             const TF e = qt[ijk]/ssa.qs * es;
             vpd[ij] = es-e;
+
+            // "Surface to air" vapor pressure deficit.
+            const TF es_bot = esat(T_bot[ij]);
+            vpds[ij] = es_bot-e;
 
             // qsat(T_bot) + dqsatdT(T_bot)
             qsat_bot[ij] = qsat(ph[k], T_bot[ij]);
@@ -1367,6 +1372,7 @@ void Thermo_moist<TF>::get_land_surface_fields_g(
     TF* const __restrict__ T_bot,
     TF* const __restrict__ T_a,
     TF* const __restrict__ vpd,
+    TF* const __restrict__ vpds,
     TF* const __restrict__ qsat_bot,
     TF* const __restrict__ dqsatdT_bot)
 {
@@ -1381,7 +1387,7 @@ void Thermo_moist<TF>::get_land_surface_fields_g(
     dim3 blockGPU(blocki, blockj, 1);
 
     calc_land_surface_fields<TF><<<gridGPU, blockGPU>>>(
-        T_bot, T_a, vpd, qsat_bot, dqsatdT_bot,
+        T_bot, T_a, vpd, vpds, qsat_bot, dqsatdT_bot,
         fields.sp.at("thl")->fld_bot_g,
         fields.sp.at("thl")->fld_g,
         fields.sp.at("qt")->fld_g,

--- a/src/thermo_moist.cxx
+++ b/src/thermo_moist.cxx
@@ -1036,6 +1036,7 @@ namespace
             TF* const restrict T_bot,
             TF* const restrict T_a,
             TF* const restrict vpd,
+            TF* const restrict vpds,
             TF* const restrict qs,
             TF* const restrict dqsdT,
             const TF* const restrict thl_bot,
@@ -1064,12 +1065,16 @@ namespace
                 T_bot[ij] = exnerh[kstart] * thl_bot[ij];   // Assuming no ql
                 T_a[ij]   = sa.t;
 
-                // Vapor pressure deficit first model level
+                // Vapor pressure deficit first model level.
                 const TF es = esat(sa.t);
                 const TF e = qt[ijk]/sa.qs * es;
                 vpd[ij] = es-e;
 
-                // qsat(T_bot) + dqsatdT(T_bot)
+                // "Surface to air" vapor pressure deficit.
+                const TF es_bot = esat(T_bot[ij]);
+                vpds[ij] = es_bot-e;
+
+                // qsat(T_bot) and dqsatdT(T_bot).
                 qs[ij] = qsat(ph[kstart], T_bot[ij]);
                 dqsdT[ij] = dqsatdT(ph[kstart], T_bot[ij]);
             }
@@ -1697,7 +1702,7 @@ void Thermo_moist<TF>::get_radiation_columns(
 template<typename TF>
 void Thermo_moist<TF>::get_land_surface_fields(
         std::vector<TF>& T_bot, std::vector<TF>& T_a, std::vector<TF>& vpd,
-        std::vector<TF>& qsat, std::vector<TF>& dqsatdT)
+        std::vector<TF>& vpds, std::vector<TF>& qsat, std::vector<TF>& dqsatdT)
 {
     /* Calculate the thermo fields required by the LSM in
        2D slices in the 3D tmp field */
@@ -1707,6 +1712,7 @@ void Thermo_moist<TF>::get_land_surface_fields(
             T_bot.data(),
             T_a.data(),
             vpd.data(),
+            vpds.data(),
             qsat.data(),
             dqsatdT.data(),
             fields.sp.at("thl")->fld_bot.data(),
@@ -1719,7 +1725,8 @@ void Thermo_moist<TF>::get_land_surface_fields(
             gd.istart, gd.iend,
             gd.jstart, gd.jend,
             gd.kstart,
-            gd.icells, gd.ijcells);
+            gd.icells,
+            gd.ijcells);
 }
 
 template<typename TF>

--- a/src/thermo_moist.cxx
+++ b/src/thermo_moist.cxx
@@ -868,7 +868,7 @@ namespace
                 T_h[ijk_nogc] = T_sfc[ij_nogc];
             }
     }
-    
+
     template<typename TF>
     void calc_radiation_fields(
             TF* restrict T, TF* restrict T_h, TF* restrict vmr_h2o, TF* restrict rh,
@@ -950,7 +950,7 @@ namespace
 
     template<typename TF>
     void calc_radiation_columns(
-            TF* const restrict T, TF* const restrict T_h, 
+            TF* const restrict T, TF* const restrict T_h,
             TF* const restrict vmr_h2o, TF* const restrict rh,
             TF* const restrict clwp, TF* const restrict ciwp, TF* const restrict T_sfc,
             const TF* const restrict thl, const TF* const restrict qt, const TF* const restrict thl_bot,
@@ -1136,9 +1136,6 @@ Thermo_moist<TF>::Thermo_moist(Master& masterin, Grid<TF>& gridin, Fields<TF>& f
     // Flag the options that are not read in init mode.
     if (sim_mode == Sim_mode::Init)
         inputin.flag_as_used("thermo", "pbot", "");
-    // if (sim_mode == Sim_mode::Run)
-    
-
 }
 
 template<typename TF>
@@ -1187,8 +1184,21 @@ void Thermo_moist<TF>::save(const int iotime)
         else
             master.print_message("OK\n");
 
+        fwrite(&bs.thl0 [gd.kstart], sizeof(TF), gd.ktot, pFile);
+        fwrite(&bs.qt0  [gd.kstart], sizeof(TF), gd.ktot, pFile);
+
         fwrite(&bs.thvref [gd.kstart], sizeof(TF), gd.ktot  , pFile);
         fwrite(&bs.thvrefh[gd.kstart], sizeof(TF), gd.ktot+1, pFile);
+
+        fwrite(&bs.pref [gd.kstart], sizeof(TF), gd.ktot  , pFile);
+        fwrite(&bs.prefh[gd.kstart], sizeof(TF), gd.ktot+1, pFile);
+
+        fwrite(&bs.exnref [gd.kstart], sizeof(TF), gd.ktot  , pFile);
+        fwrite(&bs.exnrefh[gd.kstart], sizeof(TF), gd.ktot+1, pFile);
+
+        fwrite(&bs.rhoref [gd.kstart], sizeof(TF), gd.ktot  , pFile);
+        fwrite(&bs.rhorefh[gd.kstart], sizeof(TF), gd.ktot+1, pFile);
+
         fclose(pFile);
     }
 
@@ -1202,7 +1212,7 @@ void Thermo_moist<TF>::save(const int iotime)
         std::snprintf(filename, 256, "%s.%07d", name.c_str(), iotime);
         master.print_message("Saving \"%s\" ... ", filename);
         TF no_offset = 0.;
-        
+
         const int kslice = 0;
         if (field3d_io.save_xy_slice(
                 field, no_offset, tmp1->fld.data(), filename, kslice))
@@ -1249,10 +1259,28 @@ void Thermo_moist<TF>::load(const int iotime)
         else
         {
             master.print_message("OK\n");
-            if (fread(&bs.thvref [gd.kstart], sizeof(TF), gd.ktot  , pFile) != (unsigned)gd.ktot )
-                ++nerror;
-            if (fread(&bs.thvrefh[gd.kstart], sizeof(TF), gd.ktot+1, pFile) != (unsigned)gd.ktot + 1)
-                ++nerror;
+
+            auto read = [&](std::vector<TF>& prof, const int size)
+            {
+                if (fread(&prof[gd.kstart], sizeof(TF), size, pFile) != (unsigned)size )
+                    ++nerror;
+            };
+
+            read(bs.thl0, gd.ktot);
+            read(bs.qt0, gd.ktot);
+
+            read(bs.thvref, gd.ktot);
+            read(bs.thvrefh, gd.ktot+1);
+
+            read(bs.pref, gd.ktot);
+            read(bs.prefh, gd.ktot+1);
+
+            read(bs.exnref, gd.ktot);
+            read(bs.exnrefh, gd.ktot+1);
+
+            read(bs.rhoref, gd.ktot);
+            read(bs.rhorefh, gd.ktot+1);
+
             fclose(pFile);
         }
     }
@@ -1296,12 +1324,17 @@ void Thermo_moist<TF>::load(const int iotime)
 }
 
 template<typename TF>
-void Thermo_moist<TF>::create_basestate(Input& inputin, Netcdf_handle& input_nc)
+void Thermo_moist<TF>::create_basestate(
+        Input& inputin, Netcdf_handle& input_nc, Timeloop<TF>& timeloop)
 {
     auto& gd = grid.get_grid_data();
 
     // Enable automated calculation of horizontally averaged fields
     fields.set_calc_mean_profs(true);
+
+    std::string timedep_dim = "time_surface";
+    tdep_pbot->create_timedep(input_nc, timedep_dim);
+    tdep_pbot->update_time_dependent(bs.pbot, timeloop);
 
     // Calculate the base state profiles. With swupdatebasestate=1, these profiles are updated on every iteration.
     // 1. Take the initial profile as the reference
@@ -1354,8 +1387,6 @@ void Thermo_moist<TF>::create(
     std::string timedep_dim = "time_surface";
     tdep_pbot->create_timedep(input_nc, timedep_dim);
     tdep_pbot->update_time_dependent(bs.pbot, timeloop);
-
-    create_basestate(inputin, input_nc);
 
     // Init the toolbox classes.
     boundary_cyclic.init();


### PR DESCRIPTION
This branch contains:
1. The A-Gs scheme to calculate the canopy resistance and CO2 exchange.
2. Switch from tiled stability (`ustar`, `ra`, ..) to bulk stability, since it does not make sense to have a single z0 per grid point, but vary e.g. `ra` at sub-grid level.

Work in progress!