### PR TITLE
Cuda 13.1 linking issues fix

### DIFF
--- a/include/tools.h
+++ b/include/tools.h
@@ -44,8 +44,13 @@ namespace Tools_g
     template<typename TF>
     void reduce_all(const TF *, TF *, int, int, int, Reduce_type, TF);
     template<typename TF> __global__
-    void set_to_val(TF* __restrict__, int, TF);
+    void set_to_val_kernel(TF* __restrict__, int, TF);
     template<typename TF> __global__
+    void mult_by_val_kernel(TF* __restrict__, int, TF);
+
+    template<typename TF>
+    void set_to_val(TF* __restrict__, int, TF);
+    template<typename TF>
     void mult_by_val(TF* __restrict__, int, TF);
 
     struct cuda_exception : public std::exception

--- a/src/boundary_surface_lsm.cu
+++ b/src/boundary_surface_lsm.cu
@@ -507,13 +507,10 @@ void Boundary_surface_lsm<TF>::exec(
 
     if (sw_homogenize_sfc)
     {
-        const int blockGPU = 256;
-        const int gridGPU = gd.ijcells/blockGPU + (gd.ijcells%blockGPU > 0);
-
         auto homogenize = [&](TF* const __restrict__ field)
         {
             const TF mean_value = field3d_operators.calc_mean_2d_g(field);
-            Tools_g::set_to_val<<<gridGPU, blockGPU>>>(field, gd.ijcells, mean_value);
+            Tools_g::set_to_val<TF>(field, gd.ijcells, mean_value);
         };
 
         // Homogenize the surface fields which interact with the atmosphere.

--- a/src/radiation_gcss.cu
+++ b/src/radiation_gcss.cu
@@ -262,9 +262,7 @@ void Radiation_gcss<TF>::exec(Thermo<TF>& thermo, double time, Timeloop<TF>& tim
             gd.istart, gd.iend, gd.jstart, gd.jend, gd.kstart, gd.kend,
             gd.icells, gd.ijcells, gd.ncells);
 
-        const int nblock = 256;
-        const int ngrid  = gd.ncells/nblock + (gd.ncells%nblock > 0);
-        mult_by_val<TF><<<ngrid, nblock>>>(flx->fld_g, gd.ncells, TF(-1.));
+        Tools_g::mult_by_val<TF>(flx->fld_g, gd.ncells, TF(-1.));
 
         update_temperature<TF><<<gridGPU3D, blockGPU>>>(
             fields.st.at("thl")->fld_g, flx->fld_g, Constants::cp<TF>, fields.rhoref_g,
@@ -346,9 +344,7 @@ void Radiation_gcss<TF>::get_radiation_field_g(Field3d<TF>& fld, std::string nam
         }
         else
         {
-            const int nblock = 256;
-            const int ngrid  = gd.ncells/nblock + (gd.ncells%nblock > 0);
-            set_to_val<TF><<<ngrid, nblock>>>(fld.fld_g, gd.ncells, TF(0.));
+            Tools_g::set_to_val<TF>(fld.fld_g, gd.ncells, TF(0.));
         }
     }
     else

--- a/src/tools.cu
+++ b/src/tools.cu
@@ -216,7 +216,7 @@ namespace Tools_g
     }
 
     template<typename TF> __global__
-    void set_to_val(TF* __restrict__ a, int nsize, TF val)
+    void set_to_val_kernel(TF* __restrict__ a, int nsize, TF val)
     {
         const int n = blockIdx.x*blockDim.x + threadIdx.x;
 
@@ -224,13 +224,31 @@ namespace Tools_g
             a[n] = val;
     }
 
+    template<typename TF>
+    void set_to_val(TF* __restrict__ a, int nsize, TF val)
+    {
+        const int nblock = 256;
+        const int ngrid  = nsize/nblock + (nsize%nblock > 0);
+        set_to_val_kernel<TF><<<ngrid, nblock>>>(a, nsize, val);
+        cuda_check_error();
+    }
+
     template<typename TF> __global__
-    void mult_by_val(TF* __restrict__ a, int nsize, TF val)
+    void mult_by_val_kernel(TF* __restrict__ a, int nsize, TF val)
     {
         const int n = blockIdx.x*blockDim.x + threadIdx.x;
 
         if (n < nsize)
             a[n] *= val;
+    }
+
+    template<typename TF>
+    void mult_by_val(TF* __restrict__ a, int nsize, TF val)
+    {
+        const int nblock = 256;
+        const int ngrid  = nsize/nblock + (nsize%nblock > 0);
+        mult_by_val_kernel<TF><<<ngrid, nblock>>>(a, nsize, val);
+        cuda_check_error();
     }
 
     int next_pow_of_2(unsigned int x)
@@ -343,7 +361,7 @@ template void Tools_g::reduce_interior<double>(const double*, double*, int, int,
 template void Tools_g::reduce_interior<float>(const float*, float*, int, int, int, int, int, int, int, int, int, int, Tools_g::Reduce_type);
 template void Tools_g::reduce_all<double>(const double*, double*, int, int, int, Tools_g::Reduce_type, double);
 template void Tools_g::reduce_all<float>(const float*, float*, int, int, int, Tools_g::Reduce_type, float);
-template  __global__ void Tools_g::set_to_val(double* __restrict__, int, double);
-template  __global__ void Tools_g::set_to_val(float* __restrict__, int, float);
-template  __global__ void Tools_g::mult_by_val(double* __restrict__, int, double);
-template  __global__ void Tools_g::mult_by_val(float* __restrict__, int, float);
+template void Tools_g::set_to_val<double>(double* __restrict__, int, double);
+template void Tools_g::set_to_val<float>(float* __restrict__, int, float);
+template void Tools_g::mult_by_val<double>(double* __restrict__, int, double);
+template void Tools_g::mult_by_val<float>(float* __restrict__, int, float);


### PR DESCRIPTION
Since upgrading CUDA from 12.1 to 13.1, microhh failed to compile at the final linking stage:

```bash
[ 99%] Built target microhhc
[ 99%] Building CXX object main/CMakeFiles/microhh.dir/microhh.cxx.o
[100%] Linking CXX executable ../microhh
/usr/bin/ld: ../src/libmicrohhc.a(radiation_gcss.cu.o): in function `Radiation_gcss<float>::exec(Thermo<float>&, double, Timeloop<float>&, Stats<float>&, Aerosol<float>&, Background<float>&, Microphys<float>&)':
tmpxft_00017090_00000000-6_radiation_gcss.cudafe1.cpp:(.text._ZN14Radiation_gcssIfE4execER6ThermoIfEdR8TimeloopIfER5StatsIfER7AerosolIfER10BackgroundIfER9MicrophysIfE[_ZN14Radiation_gcssIfE4execER6ThermoIfEdR8TimeloopIfER5StatsIfER7AerosolIfER10BackgroundIfER9MicrophysIfE]+0xb52): undefined reference to `void Tools_g::mult_by_val<float>(float*, int, float)'
/usr/bin/ld: ../src/libmicrohhc.a(radiation_gcss.cu.o): in function `Radiation_gcss<float>::get_radiation_field_g(Field3d<float>&, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, Thermo<float>&, Timeloop<float>&)':
tmpxft_00017090_00000000-6_radiation_gcss.cudafe1.cpp:(.text._ZN14Radiation_gcssIfE21get_radiation_field_gER7Field3dIfENSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEER6ThermoIfER8TimeloopIfE[_ZN14Radiation_gcssIfE21get_radiation_field_gER7Field3dIfENSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEER6ThermoIfER8TimeloopIfE]+0xaa2): undefined reference to `void Tools_g::set_to_val<float>(float*, int, float)'
/usr/bin/ld: ../src/libmicrohhc.a(boundary_surface_lsm.cu.o): in function `Boundary_surface_lsm<float>::exec(Thermo<float>&, Radiation<float>&, Microphys<float>&, Timeloop<float>&)::{lambda(float*)#1}::operator()(float*) const':
tmpxft_00016cf8_00000000-6_boundary_surface_lsm.cudafe1.cpp:(.text._ZZN20Boundary_surface_lsmIfE4execER6ThermoIfER9RadiationIfER9MicrophysIfER8TimeloopIfEENKUlPfE_clESD_[_ZZN20Boundary_surface_lsmIfE4execER6ThermoIfER9RadiationIfER9MicrophysIfER8TimeloopIfEENKUlPfE_clESD_]+0xc8): undefined reference to `void Tools_g::set_to_val<float>(float*, int, float)'
/usr/bin/ld: ../microhh: hidden symbol `_ZN7Tools_g10set_to_valIfEEvPT_iS1_' isn't defined
/usr/bin/ld: final link failed: bad value
collect2: error: ld returned 1 exit status
make[2]: *** [main/CMakeFiles/microhh.dir/build.make:116: microhh] Error 1
make[1]: *** [CMakeFiles/Makefile2:497: main/CMakeFiles/microhh.dir/all] Error 2
``` 

Claude Opus 4.5 suggested that CUDA 13.1 is much stricter about templating and proceeded to fix the affected functions in `tools_cu` which weren't globally available, and in two places where these functions were called.

My compilation is now works again. Running RCEMIP with a 320K SST seems to also produce reasonable results (arguably not the best test case). 