### PR TITLE
Mirrored basestate load/save structure from moist to dry thermo.

### DIFF
--- a/include/thermo_dry.h
+++ b/include/thermo_dry.h
@@ -57,9 +57,13 @@ class Thermo_dry : public Thermo<TF>
 
         void init();
         void create(Input&, Netcdf_handle&, Stats<TF>&, Column<TF>&, Cross<TF>&, Dump<TF>&, Timeloop<TF>&);
+        void create_basestate(Input&, Netcdf_handle&, Timeloop<TF>&);
         void exec(const double, Stats<TF>&); // Add the tendencies belonging to the buoyancy.
         unsigned long get_time_limit(unsigned long, double); // Compute the time limit (n/a for thermo_dry).
         void create_stats(Stats<TF>&);   // Initialization of the statistics.
+
+        void load(const int);
+        void save(const int);
 
         void exec_stats(Stats<TF>&);
         void exec_cross(Cross<TF>&, unsigned long);
@@ -121,11 +125,6 @@ class Thermo_dry : public Thermo<TF>
                 std::vector<TF>&, std::vector<TF>&)
             { throw std::runtime_error("Function get_land_surface_fields not implemented"); }
 
-        // Empty functions that are allowed to pass.
-        void create_basestate(Input&, Netcdf_handle&, Timeloop<TF>&) {};
-        void load(const int) {};
-        void save(const int) {};
-
         void get_mask(Stats<TF>&, std::string) {};
         bool has_mask(std::string) {return false;};
 
@@ -155,7 +154,7 @@ class Thermo_dry : public Thermo<TF>
             Basestate_type swbasestate;
 
             TF pbot;   // Surface pressure.
-            TF thref0; // Reference potential temperature in case of Boussinesq
+            TF thref0; // Reference potential temperature in case of Boussinesq.
 
             std::vector<TF> thref;
             std::vector<TF> threfh;
@@ -163,6 +162,8 @@ class Thermo_dry : public Thermo<TF>
             std::vector<TF> prefh;
             std::vector<TF> exnref;
             std::vector<TF> exnrefh;
+            std::vector<TF> rhoref;
+            std::vector<TF> rhorefh;
 
             // GPU functions and variables
             TF*  thref_g;
@@ -171,7 +172,10 @@ class Thermo_dry : public Thermo<TF>
             TF*  prefh_g;
             TF*  exnref_g;
             TF*  exnrefh_g;
+            TF*  rhoref_g;
+            TF*  rhorefh_g;
         };
+
         background_state bs;
         background_state bs_stats;
 

--- a/src/thermo_dry.cu
+++ b/src/thermo_dry.cu
@@ -153,23 +153,23 @@ void Thermo_dry<TF>::prepare_device()
 
     const int nmemsize = gd.kcells*sizeof(TF);
 
-    // Allocate fields for Boussinesq and anelastic solver
     cuda_safe_call(cudaMalloc(&bs.thref_g,   nmemsize));
     cuda_safe_call(cudaMalloc(&bs.threfh_g,  nmemsize));
     cuda_safe_call(cudaMalloc(&bs.pref_g,    nmemsize));
     cuda_safe_call(cudaMalloc(&bs.prefh_g,   nmemsize));
     cuda_safe_call(cudaMalloc(&bs.exnref_g,  nmemsize));
     cuda_safe_call(cudaMalloc(&bs.exnrefh_g, nmemsize));
+    cuda_safe_call(cudaMalloc(&bs.rhoref_g,  nmemsize));
+    cuda_safe_call(cudaMalloc(&bs.rhorefh_g, nmemsize));
 
-
-    // Copy fields to device
     cuda_safe_call(cudaMemcpy(bs.thref_g,   bs.thref.data(),   nmemsize, cudaMemcpyHostToDevice));
     cuda_safe_call(cudaMemcpy(bs.threfh_g,  bs.threfh.data(),  nmemsize, cudaMemcpyHostToDevice));
     cuda_safe_call(cudaMemcpy(bs.pref_g,    bs.pref.data(),    nmemsize, cudaMemcpyHostToDevice));
     cuda_safe_call(cudaMemcpy(bs.prefh_g,   bs.prefh.data(),   nmemsize, cudaMemcpyHostToDevice));
     cuda_safe_call(cudaMemcpy(bs.exnref_g,  bs.exnref.data(),  nmemsize, cudaMemcpyHostToDevice));
     cuda_safe_call(cudaMemcpy(bs.exnrefh_g, bs.exnrefh.data(), nmemsize, cudaMemcpyHostToDevice));
-
+    cuda_safe_call(cudaMemcpy(bs.rhoref_g,  bs.rhoref.data(),  nmemsize, cudaMemcpyHostToDevice));
+    cuda_safe_call(cudaMemcpy(bs.rhorefh_g, bs.rhorefh.data(), nmemsize, cudaMemcpyHostToDevice));
 }
 
 template<typename TF>
@@ -181,6 +181,9 @@ void Thermo_dry<TF>::clear_device()
     cuda_safe_call(cudaFree(bs.prefh_g ));
     cuda_safe_call(cudaFree(bs.exnref_g ));
     cuda_safe_call(cudaFree(bs.exnrefh_g));
+    cuda_safe_call(cudaFree(bs.rhoref_g ));
+    cuda_safe_call(cudaFree(bs.rhorefh_g));
+
     tdep_pbot->clear_device();
 }
 
@@ -190,22 +193,28 @@ void Thermo_dry<TF>::forward_device()
     auto& gd = grid.get_grid_data();
 
     const int nmemsize = gd.kcells*sizeof(TF);
-    // Copy fields to device
+
     cuda_safe_call(cudaMemcpy(bs.pref_g,    bs.pref.data(),    nmemsize, cudaMemcpyHostToDevice));
     cuda_safe_call(cudaMemcpy(bs.prefh_g,   bs.prefh.data(),   nmemsize, cudaMemcpyHostToDevice));
     cuda_safe_call(cudaMemcpy(bs.exnref_g,  bs.exnref.data(),  nmemsize, cudaMemcpyHostToDevice));
     cuda_safe_call(cudaMemcpy(bs.exnrefh_g, bs.exnrefh.data(), nmemsize, cudaMemcpyHostToDevice));
+    cuda_safe_call(cudaMemcpy(bs.rhoref_g,  bs.rhoref.data(),  nmemsize, cudaMemcpyHostToDevice));
+    cuda_safe_call(cudaMemcpy(bs.rhorefh_g, bs.rhorefh.data(), nmemsize, cudaMemcpyHostToDevice));
 }
+
 template<typename TF>
 void Thermo_dry<TF>::backward_device()
 {
     auto& gd = grid.get_grid_data();
 
     const int nmemsize = gd.kcells*sizeof(TF);
+
     cudaMemcpy(bs.pref_g,    bs.pref.data(),    nmemsize, cudaMemcpyHostToDevice);
     cudaMemcpy(bs.prefh_g,   bs.prefh.data(),   nmemsize, cudaMemcpyHostToDevice);
     cudaMemcpy(bs.exnref_g,  bs.exnref.data(),  nmemsize, cudaMemcpyHostToDevice);
     cudaMemcpy(bs.exnrefh_g, bs.exnrefh.data(), nmemsize, cudaMemcpyHostToDevice);
+    cudaMemcpy(bs.rhoref_g,  bs.rhoref.data(),  nmemsize, cudaMemcpyHostToDevice);
+    cudaMemcpy(bs.rhorefh_g, bs.rhorefh.data(), nmemsize, cudaMemcpyHostToDevice);
 
     bs_stats = bs;
 }

--- a/src/thermo_dry.cxx
+++ b/src/thermo_dry.cxx
@@ -386,12 +386,124 @@ void Thermo_dry<TF>::init()
     bs.prefh.resize(gd.kcells);
     bs.exnref.resize(gd.kcells);
     bs.exnrefh.resize(gd.kcells);
+    bs.rhoref.resize(gd.kcells);
+    bs.rhorefh.resize(gd.kcells);
+}
+
+
+template<typename TF>
+void Thermo_dry<TF>::save(const int iotime)
+{
+    auto& gd = grid.get_grid_data();
+    int nerror = 0;
+
+    if ((master.get_mpiid() == 0) && iotime == 0)
+    {
+        FILE *pFile;
+        char filename[256];
+        std::snprintf(filename, 256, "%s.%07d", "thermo_basestate", iotime);
+        pFile = fopen(filename, "wbx");
+        master.print_message("Saving \"%s\" ... ", filename);
+
+        if (pFile == NULL)
+        {
+            master.print_message("FAILED\n");
+            nerror++;
+        }
+        else
+            master.print_message("OK\n");
+
+        fwrite(&bs.thref [gd.kstart], sizeof(TF), gd.ktot  , pFile);
+        fwrite(&bs.threfh[gd.kstart], sizeof(TF), gd.ktot+1, pFile);
+
+        fwrite(&bs.pref [gd.kstart], sizeof(TF), gd.ktot  , pFile);
+        fwrite(&bs.prefh[gd.kstart], sizeof(TF), gd.ktot+1, pFile);
+
+        fwrite(&bs.exnref [gd.kstart], sizeof(TF), gd.ktot  , pFile);
+        fwrite(&bs.exnrefh[gd.kstart], sizeof(TF), gd.ktot+1, pFile);
+
+        fwrite(&bs.rhoref [gd.kstart], sizeof(TF), gd.ktot  , pFile);
+        fwrite(&bs.rhorefh[gd.kstart], sizeof(TF), gd.ktot+1, pFile);
+
+        fclose(pFile);
+    }
+
+    master.sum(&nerror, 1);
+    if (nerror)
+        throw std::runtime_error("Error in writing thermo_basestate");
 }
 
 template<typename TF>
-void Thermo_dry<TF>::create(
-        Input& inputin, Netcdf_handle& input_nc, Stats<TF>& stats,
-        Column<TF>& column, Cross<TF>& cross, Dump<TF>& dump, Timeloop<TF>& timeloop)
+void Thermo_dry<TF>::load(const int iotime)
+{
+    auto& gd = grid.get_grid_data();
+
+    int nerror = 0;
+    const int iotime_io = 0;
+
+    if ((master.get_mpiid() == 0))
+    {
+        char filename[256];
+        std::snprintf(filename, 256, "%s.%07d", "thermo_basestate", iotime_io);
+
+        std::printf("Loading \"%s\" ... ", filename);
+
+        FILE* pFile;
+        pFile = fopen(filename, "rb");
+        if (pFile == NULL)
+        {
+            master.print_message("FAILED\n");
+            ++nerror;
+        }
+        else
+        {
+            master.print_message("OK\n");
+
+            auto read = [&](std::vector<TF>& prof, const int size)
+            {
+                if (fread(&prof[gd.kstart], sizeof(TF), size, pFile) != (unsigned)size)
+                    ++nerror;
+            };
+
+            read(bs.thref, gd.ktot);
+            read(bs.threfh, gd.ktot+1);
+
+            read(bs.pref, gd.ktot);
+            read(bs.prefh, gd.ktot+1);
+
+            read(bs.exnref, gd.ktot);
+            read(bs.exnrefh, gd.ktot+1);
+
+            read(bs.rhoref, gd.ktot);
+            read(bs.rhorefh, gd.ktot+1);
+
+            fclose(pFile);
+        }
+    }
+
+    // Communicate the file read error over all procs.
+    master.sum(&nerror, 1);
+    if (nerror)
+        throw std::runtime_error("Error in loading thermo_moist basestate");
+
+    // Broadcast to other MPI tasks.
+    master.broadcast(bs.thref.data(), gd.kcells);
+    master.broadcast(bs.threfh.data(), gd.kcells);
+
+    master.broadcast(bs.pref.data(), gd.kcells);
+    master.broadcast(bs.prefh.data(), gd.kcells);
+
+    master.broadcast(bs.exnref.data(), gd.kcells);
+    master.broadcast(bs.exnrefh.data(), gd.kcells);
+
+    master.broadcast(bs.rhoref.data(), gd.kcells);
+    master.broadcast(bs.rhorefh.data(), gd.kcells);
+}
+
+
+template<typename TF>
+void Thermo_dry<TF>::create_basestate(
+        Input& inputin, Netcdf_handle& input_nc, Timeloop<TF>& timeloop)
 {
     auto& gd = grid.get_grid_data();
     fields.set_calc_mean_profs(true);
@@ -414,9 +526,23 @@ void Thermo_dry<TF>::create(
         std::rotate(bs.thref.rbegin(), bs.thref.rbegin() + gd.kstart, bs.thref.rend());
 
         calc_base_state(
-                fields.rhoref.data(), fields.rhorefh.data(), bs.pref.data(), bs.prefh.data(),
-                bs.exnref.data(), bs.exnrefh.data(), bs.thref.data(), bs.threfh.data(), bs.pbot,
-                gd.z.data(), gd.zh.data(), gd.dz.data(), gd.dzh.data(), gd.dzhi.data(), gd.kstart, gd.kend, gd.kcells);
+                bs.rhoref.data(),
+                bs.rhorefh.data(),
+                bs.pref.data(),
+                bs.prefh.data(),
+                bs.exnref.data(),
+                bs.exnrefh.data(),
+                bs.thref.data(),
+                bs.threfh.data(),
+                bs.pbot,
+                gd.z.data(),
+                gd.zh.data(),
+                gd.dz.data(),
+                gd.dzh.data(),
+                gd.dzhi.data(),
+                gd.kstart,
+                gd.kend,
+                gd.kcells);
     }
     else
     {
@@ -426,19 +552,44 @@ void Thermo_dry<TF>::create(
         // Set entire column to reference value. Density is already initialized at 1.0 in fields.cxx.
         for (int k=0; k<gd.kcells; ++k)
         {
+            bs.rhoref[k]  = 1.;
+            bs.rhorefh[k] = 1.;
             bs.thref[k]  = bs.thref0;
             bs.threfh[k] = bs.thref0;
         }
 
         // Calculate hydrostatic pressure
         calc_hydrostatic_pressure(
-                bs.pref.data(), bs.prefh.data(),
-                bs.exnref.data(), bs.exnrefh.data(),
-                bs.thref.data(), bs.threfh.data(),
-                gd.z.data(), gd.zh.data(),
-                gd.dz.data(), gd.dzh.data(), gd.dzhi.data(),
-                bs.pbot, gd.kstart, gd.kend, gd.kcells);
+                bs.pref.data(),
+                bs.prefh.data(),
+                bs.exnref.data(),
+                bs.exnrefh.data(),
+                bs.thref.data(),
+                bs.threfh.data(),
+                gd.z.data(),
+                gd.zh.data(),
+                gd.dz.data(),
+                gd.dzh.data(),
+                gd.dzhi.data(),
+                bs.pbot,
+                gd.kstart,
+                gd.kend,
+                gd.kcells);
     }
+
+    // Copy the initial reference to the fields. This is the reference used in the dynamics.
+    // This one is not updated throughout the simulation to be consistent with the anelastic approximation.
+    fields.rhoref = bs.rhoref;
+    fields.rhorefh = bs.rhorefh;
+}
+
+template<typename TF>
+void Thermo_dry<TF>::create(
+        Input& inputin, Netcdf_handle& input_nc, Stats<TF>& stats,
+        Column<TF>& column, Cross<TF>& cross, Dump<TF>& dump, Timeloop<TF>& timeloop)
+{
+    auto& gd = grid.get_grid_data();
+    fields.set_calc_mean_profs(true);
 
     // Init the toolbox classes.
     boundary_cyclic.init();

--- a/src/thermo_moist.cxx
+++ b/src/thermo_moist.cxx
@@ -1117,7 +1117,6 @@ Thermo_moist<TF>::Thermo_moist(Master& masterin, Grid<TF>& gridin, Fields<TF>& f
     else
         throw std::runtime_error("Invalid option for \"swbasestate\"");
 
-
     // BvS test for updating hydrostatic prssure during run
     // swupdate..=0 -> initial base state pressure used in saturation calculation
     // swupdate..=1 -> base state pressure updated before saturation calculation


### PR DESCRIPTION
`thermo_dry` was working correctly (correct density in case of anelastic), but because of recent changes in `thermo_moist`, the incorrect basestate density (`rho=1`) was written to the statistics, causing the mass conservation check in `dispersion` to fail.

I mirrored the load/save structure from `moist` to `dry` to make things consistent. This fixes the mass conservation check, checked both in the CPU and GPU version:

    (default) bart@eddy:~/meteo/models/microhh/cases/dispersion$ python check_mass_conservation.py 
    Time =     0, scalar "s1": correct mass =     0.00 kg, integral field =     0.00 kg
    Time =     0, scalar "s2": correct mass =     0.00 kg, integral field =     0.00 kg
    Time =  3600, scalar "s1": correct mass =  3600.00 kg, integral field =  1205.61 kg
    Time =  3600, scalar "s2": correct mass =  3600.00 kg, integral field =  3600.00 kg
