### PR TITLE
(OpenBC) Fix dump interval and boundary output bugs

### DIFF
--- a/src/dump.cxx
+++ b/src/dump.cxx
@@ -181,7 +181,7 @@ void Dump<TF>::save_dump(TF* data, const std::string& varname, int iotime)
     const double no_offset = 0.;
     char filename[256];
 
-    if (swdump && iotime % 21600 == 0)
+    if (swdump)
     {
         std::snprintf(filename, 256, "%s.%07d", varname.c_str(), iotime);
         std::ifstream infile(filename);

--- a/src/model.cxx
+++ b/src/model.cxx
@@ -547,7 +547,7 @@ void Model<TF>::exec()
                                 *thermo, *timeloop,
                                 itime, iotime);
 
-                        #pragma omp task default(shared)
+                        #pragma omp task default(shared) firstprivate(iter, time, itime, idt, iotime, dt)
                         calculate_statistics(iter, time, itime, idt, iotime, dt);
                     }
 

--- a/src/model.cxx
+++ b/src/model.cxx
@@ -607,7 +607,7 @@ void Model<TF>::exec()
                         // leading to restart failures.
                         thermo->save(iotime);
 
-                        #pragma omp task default(shared)
+                        #pragma omp task default(shared) firstprivate(iotime, itime, idt, iteration)
                         {
                             timeloop->save(iotime, itime, idt, iteration);
                             fields  ->save(iotime);


### PR DESCRIPTION
- Dump interval being arbitrarily fixed to 21600
- Lat boundary outputs having nonsensical timestamps